### PR TITLE
feat: add --no-open flag to disable auto-opening browser

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,6 +21,7 @@ export class CLI {
           .option('-H, --host <host>', 'Host to listen on', 'localhost')
           .option('-p, --port <port>', 'Port to serve on', String(DEFAULT_PORT))
           .option('-s, --silent', 'Suppress server logs', false)
+          .option('--no-open', 'Do not open the browser automatically')
           .argument('[directory]', 'Directory to serve', DEFAULT_DIRECTORY)
           .action((directory, options) => {
             logger.setSilent(options.silent);
@@ -37,8 +38,12 @@ export class CLI {
             const readmePath = path.join(absoluteDirectory, 'README.md');
             const initialPath = existsSync(readmePath) ? '/README.md' : '';
             const displayHost = (host === '0.0.0.0' || host === '::') ? 'localhost' : host;
-            logger.log('CLI', `🌐 Opening browser at http://${displayHost}:${port}${initialPath}`);
-            open(`http://${displayHost}:${port}${initialPath}`);
+            if (options.open) {
+              logger.log('CLI', `🌐 Opening browser at http://${displayHost}:${port}${initialPath}`);
+              open(`http://${displayHost}:${port}${initialPath}`);
+            } else {
+              logger.log('CLI', `🌐 Server running at http://${displayHost}:${port}${initialPath}`);
+            }
           });
 
         program.parse(process.argv);


### PR DESCRIPTION
close: #453

## Summary
- Add `--no-open` CLI flag to prevent the browser from automatically opening when the server starts
- When `--no-open` is used, the server URL is displayed in the terminal instead of opening the browser
- Useful for automation and orchestration tools like Tilt

## Test plan
- [ ] Run `mdts` without flag and verify browser opens automatically
- [ ] Run `mdts --no-open` and verify browser does not open
- [ ] Verify server URL is displayed in both cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--no-open` CLI flag to disable automatic browser opening when starting the server. Users can now launch the server without automatically triggering a browser window.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->