### PR TITLE
chore: migrate to npm trusted publishing with OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -51,7 +52,4 @@ jobs:
         run: npm run build:frontend
 
       - name: Publish to npm
-        run: |
-          npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish


### PR DESCRIPTION
## Summary
- Replace `NPM_TOKEN` secret with OIDC-based trusted publishing
- Add `id-token: write` permission for OIDC token generation
- Eliminates need to manage long-lived npm tokens

## Setup Required
Before merging, configure trusted publisher on https://www.npmjs.com/package/mdts/access:
- Organization: `unhappychoice`
- Repository: `mdts`
- Workflow: `release.yml`

## Test plan
- [ ] Configure trusted publisher on npmjs.com
- [ ] Merge this PR
- [ ] Run release workflow and verify npm publish succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow configuration to streamline the npm publishing process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->