### PR TITLE
feat: support index.md as default page fallback

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -49,8 +49,9 @@ export class CLI {
               process.exitCode = 1;
               return;
             }
-            const readmePath = path.join(context.directory, 'README.md');
-            const initialPath = existsSync(readmePath) ? '/README.md' : '';
+            const defaultPages = ['README.md', 'index.md'];
+            const defaultPage = defaultPages.find((name) => existsSync(path.join(context.directory, name)));
+            const initialPath = defaultPage ? `/${defaultPage}` : '';
             const displayHost = (host === '0.0.0.0' || host === '::') ? 'localhost' : host;
             if (options.open) {
               logger.log('CLI', `🌐 Opening browser at http://${displayHost}:${actualPort}${initialPath}`);

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -4,9 +4,9 @@ import { serve } from '../../src/server/server';
 import { resolveGlobPatterns } from '../../src/utils/glob';
 
 // Mock fs first, before any other imports that might use it
-let mockExistsSyncResult = false;
+let mockExistingFiles: string[] = [];
 jest.mock('fs', () => ({
-  existsSync: jest.fn(() => mockExistsSyncResult),
+  existsSync: jest.fn((p: string) => mockExistingFiles.some((name) => p.endsWith(name))),
   readFileSync: jest.fn(() => JSON.stringify({
     version: '0.0.0-test',
   })),
@@ -17,7 +17,10 @@ jest.mock('fs', () => ({
 
 // Helper to set the mock result for existsSync
 const setExistsSyncResult = (result: boolean) => {
-  mockExistsSyncResult = result;
+  mockExistingFiles = result ? ['README.md', 'index.md'] : [];
+};
+const setExistingFiles = (files: string[]) => {
+  mockExistingFiles = files;
 };
 
 // Mock the 'open' module
@@ -56,7 +59,7 @@ describe('cli', () => {
     originalArgv = process.argv;
     mockServe = serve as jest.Mock;
     // Reset the mock result for existsSync before each test
-    setExistsSyncResult(false); // Default to false for safety
+    setExistingFiles([]); // Default to empty for safety
     jest.clearAllMocks();
 
     jest.spyOn(cli, 'requireOpen')
@@ -86,6 +89,26 @@ describe('cli', () => {
       .then(() => {
         expect(mockServe).toHaveBeenCalledWith({ directory: path.resolve('.') }, 8521, 'localhost', false);
         expect(mockOpen).toHaveBeenCalledWith('http://localhost:8521');
+      });
+  });
+
+  it('should fall back to index.md when README.md does not exist', () => {
+    setExistingFiles(['index.md']);
+    process.argv = ['node', 'cli.ts', '.'];
+
+    return cli.run()
+      .then(() => {
+        expect(mockOpen).toHaveBeenCalledWith('http://localhost:8521/index.md');
+      });
+  });
+
+  it('should prefer README.md over index.md when both exist', () => {
+    setExistingFiles(['README.md', 'index.md']);
+    process.argv = ['node', 'cli.ts', '.'];
+
+    return cli.run()
+      .then(() => {
+        expect(mockOpen).toHaveBeenCalledWith('http://localhost:8521/README.md');
       });
   });
 


### PR DESCRIPTION
## Summary
- Resolve `index.md` as the default landing page when `README.md` is absent, in addition to the existing `README.md` behavior
- Resolution order: `README.md` → `index.md`

Close #533

## Test plan
- [x] `npx jest test/unit/cli.test.ts` passes (12/12)
- [x] `npx tsc --noEmit` passes
- [ ] Manual: `mdts` in a dir with only `index.md` opens `/index.md`
- [ ] Manual: `mdts` in a dir with both opens `/README.md`
- [ ] Manual: `mdts` in a dir with neither opens root

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the CLI's default page selection to intelligently check multiple documentation files in priority order and gracefully fall back to alternatives when the preferred file is unavailable, ensuring better reliability when launching documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->