### PR TITLE
feat: mobile responsive layout (#657)

### DIFF
--- a/packages/frontend/src/Layout.tsx
+++ b/packages/frontend/src/Layout.tsx
@@ -6,6 +6,7 @@ import AppHeader from './components/AppHeader';
 import Content from './components/Content/Content';
 import FileTree from './components/LeftPane/FileTree';
 import Outline from './components/RightPane/Outline';
+import useIsMobile from './hooks/useIsMobile';
 import { toggleFileTree, toggleOutline, } from './store/slices/appSettingSlice';
 import { RootState } from './store/store';
 
@@ -16,10 +17,13 @@ interface LayoutProps {
 const Layout: React.FC<LayoutProps> = ({ onSettingsClick }) => {
   const dispatch = useDispatch();
   const navigate = useNavigate();
+  const isMobile = useIsMobile();
   const { fileTreeOpen, outlineOpen } = useSelector((state: RootState) => state.appSetting);
   const { currentPath, isDirectory } = useSelector((state: RootState) => state.history);
   const { fontFamily, fontFamilyMonospace } = useSelector((state: RootState) => state.config);
   const [scrollToId, setScrollToId] = useState<string | null>(null);
+  const [mobileFileTreeOpen, setMobileFileTreeOpen] = useState(false);
+  const [mobileOutlineOpen, setMobileOutlineOpen] = useState(false);
 
   useEffect(() => {
     document.documentElement.style.setProperty('--markdown-font-family', fontFamily);
@@ -29,13 +33,25 @@ const Layout: React.FC<LayoutProps> = ({ onSettingsClick }) => {
     document.documentElement.style.setProperty('--markdown-monospace-font-family', fontFamilyMonospace);
   }, [fontFamilyMonospace]);
 
+  useEffect(() => {
+    if (!isMobile) {
+      setMobileFileTreeOpen(false);
+      setMobileOutlineOpen(false);
+    }
+  }, [isMobile]);
+
   const handleFileSelect = useCallback((path: string) => {
     navigate(`/${path}`);
   }, [navigate]);
 
   const handleToggleFileTree = useCallback(() => {
-    dispatch(toggleFileTree());
-  }, [dispatch, toggleFileTree]);
+    if (isMobile) {
+      setMobileFileTreeOpen((prev) => !prev);
+      setMobileOutlineOpen(false);
+    } else {
+      dispatch(toggleFileTree());
+    }
+  }, [dispatch, isMobile]);
 
   const handleDirectorySelect = useCallback((path: string) => {
     navigate(`/${path}`);
@@ -46,14 +62,24 @@ const Layout: React.FC<LayoutProps> = ({ onSettingsClick }) => {
   }, []);
 
   const handleToggleOutline = useCallback(() => {
-    dispatch(toggleOutline());
-  }, [dispatch, toggleOutline]);
+    if (isMobile) {
+      setMobileOutlineOpen((prev) => !prev);
+      setMobileFileTreeOpen(false);
+    } else {
+      dispatch(toggleOutline());
+    }
+  }, [dispatch, isMobile]);
+
+  const fileTreeIsOpen = isMobile ? mobileFileTreeOpen : fileTreeOpen;
+  const outlineIsOpen = isMobile ? mobileOutlineOpen : outlineOpen;
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
       <AppHeader
         handleFileSelect={handleFileSelect}
         onSettingsClick={onSettingsClick}
+        onToggleFileTree={handleToggleFileTree}
+        onToggleOutline={handleToggleOutline}
       />
       <Box
         component="main"
@@ -61,7 +87,7 @@ const Layout: React.FC<LayoutProps> = ({ onSettingsClick }) => {
       >
         <FileTree
           onFileSelect={handleFileSelect}
-          isOpen={fileTreeOpen}
+          isOpen={fileTreeIsOpen}
           onToggle={handleToggleFileTree}
           selectedFilePath={currentPath}
         />
@@ -73,7 +99,7 @@ const Layout: React.FC<LayoutProps> = ({ onSettingsClick }) => {
         <Outline
           filePath={isDirectory ? null : currentPath}
           onItemClick={handleOutlineItemClick}
-          isOpen={outlineOpen}
+          isOpen={outlineIsOpen}
           onToggle={handleToggleOutline}
         />
       </Box>

--- a/packages/frontend/src/components/AppHeader.tsx
+++ b/packages/frontend/src/components/AppHeader.tsx
@@ -1,19 +1,27 @@
 import GitHubIcon from '@mui/icons-material/GitHub';
+import MenuIcon from '@mui/icons-material/Menu';
+import SegmentIcon from '@mui/icons-material/Segment';
 import SettingsIcon from '@mui/icons-material/Settings';
 import { AppBar, Box, IconButton, Link, Toolbar, Tooltip } from '@mui/material';
 import React, { useCallback } from 'react';
 
+import useIsMobile from '../hooks/useIsMobile';
 import Logo from './Logo';
 
 interface AppHeaderProps {
   handleFileSelect: (path: string) => void;
   onSettingsClick: () => void;
+  onToggleFileTree?: () => void;
+  onToggleOutline?: () => void;
 }
 
 const AppHeader: React.FC<AppHeaderProps> = ({
   handleFileSelect,
   onSettingsClick,
+  onToggleFileTree,
+  onToggleOutline,
 }) => {
+  const isMobile = useIsMobile();
   const handleFileSelectClick = useCallback(() => {
     handleFileSelect('');
   }, [handleFileSelect]);
@@ -25,6 +33,19 @@ const AppHeader: React.FC<AppHeaderProps> = ({
       sx={{ bgcolor: 'background.paper', color: 'text.primary', borderBottom: '1px solid ', borderColor: 'divider' }}
     >
       <Toolbar>
+        {isMobile && onToggleFileTree && (
+          <Tooltip title="Toggle file tree">
+            <IconButton
+              onClick={onToggleFileTree}
+              edge="start"
+              color="inherit"
+              sx={{ mr: 1 }}
+              aria-label="toggle file tree"
+            >
+              <MenuIcon />
+            </IconButton>
+          </Tooltip>
+        )}
         <Box sx={{ flexGrow: 1 }}>
           <Tooltip title="Top page">
             <IconButton disableRipple onClick={handleFileSelectClick} color="inherit">
@@ -34,29 +55,45 @@ const AppHeader: React.FC<AppHeaderProps> = ({
             </IconButton>
           </Tooltip>
         </Box>
+        {isMobile && onToggleOutline && (
+          <Tooltip title="Toggle outline">
+            <IconButton
+              onClick={onToggleOutline}
+              color="inherit"
+              sx={{ mr: 1 }}
+              aria-label="toggle outline"
+            >
+              <SegmentIcon />
+            </IconButton>
+          </Tooltip>
+        )}
         <Tooltip title="Settings">
-          <IconButton sx={{ mr: 2 }} onClick={onSettingsClick} color="inherit">
+          <IconButton sx={{ mr: isMobile ? 0 : 2 }} onClick={onSettingsClick} color="inherit">
             <SettingsIcon />
           </IconButton>
         </Tooltip>
-        <Tooltip title="GitHub Repository">
-          <IconButton
-            color="inherit"
-            href="https://github.com/unhappychoice/mdts"
-            target="_blank"
-            rel="noopener"
-            sx={{ mr: 2 }}
-          >
-            <GitHubIcon />
-          </IconButton>
-        </Tooltip>
-        <Box sx={{ fontSize: '0.9rem', pt: '2px', fontFamily: 'monospace' }}>
-          <Tooltip title="Changelog">
-            <Link href="https://github.com/unhappychoice/mdts/blob/main/CHANGELOG.md" target="_blank" rel="noopener">
-              v{process.env.APP_VERSION}
-            </Link>
+        {!isMobile && (
+          <Tooltip title="GitHub Repository">
+            <IconButton
+              color="inherit"
+              href="https://github.com/unhappychoice/mdts"
+              target="_blank"
+              rel="noopener"
+              sx={{ mr: 2 }}
+            >
+              <GitHubIcon />
+            </IconButton>
           </Tooltip>
-        </Box>
+        )}
+        {!isMobile && (
+          <Box sx={{ fontSize: '0.9rem', pt: '2px', fontFamily: 'monospace' }}>
+            <Tooltip title="Changelog">
+              <Link href="https://github.com/unhappychoice/mdts/blob/main/CHANGELOG.md" target="_blank" rel="noopener">
+                v{process.env.APP_VERSION}
+              </Link>
+            </Tooltip>
+          </Box>
+        )}
       </Toolbar>
     </AppBar>
   );

--- a/packages/frontend/src/components/Content/Content.tsx
+++ b/packages/frontend/src/components/Content/Content.tsx
@@ -50,7 +50,9 @@ const Content: React.FC<ContentProps> = ({ onFileSelect, onDirectorySelect, scro
         className="custom-scrollbar"
         sx={{
           overflowY: 'scroll',
+          overflowX: 'auto',
           width: '100%',
+          minWidth: 0,
         }}
       >
         {currentPath && isDirectory ? (

--- a/packages/frontend/src/components/Content/DirectoryContent/DirectoryContent.tsx
+++ b/packages/frontend/src/components/Content/DirectoryContent/DirectoryContent.tsx
@@ -2,6 +2,7 @@ import { FolderOutlined } from '@mui/icons-material';
 import { Box, CircularProgress, Divider, Typography } from '@mui/material';
 import React, { useCallback } from 'react';
 import { useSelector } from 'react-redux';
+import useIsMobile from '../../../hooks/useIsMobile';
 import { selectFilteredFileTree } from '../../../store/slices/fileTreeSlice';
 import { RootState } from '../../../store/store';
 import ErrorView from '../../ErrorView';
@@ -17,6 +18,7 @@ const DirectoryContent: React.FC<DirectoryContentProps> = ({ onFileSelect, onDir
   const { currentPath } = useSelector((state: RootState) => state.history);
   const { contentMode } = useSelector((state: RootState) => state.appSetting);
   const { fileTree: fullFileTree, loading, error } = useSelector((state: RootState) => state.fileTree);
+  const isMobile = useIsMobile();
 
   const fileTree = selectFilteredFileTree(fullFileTree, currentPath);
 
@@ -38,9 +40,9 @@ const DirectoryContent: React.FC<DirectoryContentProps> = ({ onFileSelect, onDir
         width: '100%',
         minHeight: 'calc(100vh - 64px)',
         m: 0,
-        p: 4,
+        p: isMobile ? 2 : 4,
         bgcolor: 'background.paper',
-        ...(contentMode === 'compact' && {
+        ...(contentMode === 'compact' && !isMobile && {
           width: '800px',
           margin: '0 auto',
         })
@@ -48,12 +50,12 @@ const DirectoryContent: React.FC<DirectoryContentProps> = ({ onFileSelect, onDir
     >
       <BreadCrumb onDirectorySelect={onDirectorySelect} />
       <Box sx={{ display: 'flex', alignItems: 'center', mb: 4 }}>
-        <FolderOutlined sx={{ mr: 2 }} color="primary" fontSize="large" />
-        <Typography variant="h4" gutterBottom sx={{ mb: 0 }}>
+        <FolderOutlined sx={{ mr: 2 }} color="primary" fontSize={isMobile ? 'medium' : 'large'} />
+        <Typography variant={isMobile ? 'h5' : 'h4'} gutterBottom sx={{ mb: 0, wordBreak: 'break-word' }}>
           {currentPath}
         </Typography>
       </Box>
-      <Divider sx={{ paddingLeft: '24px', marginLeft: '-32px', marginRight: '-32px', borderBottom: 1, borderColor: 'divider' }} />
+      <Divider sx={{ paddingLeft: '24px', marginLeft: isMobile ? '-16px' : '-32px', marginRight: isMobile ? '-16px' : '-32px', borderBottom: 1, borderColor: 'divider' }} />
       {loading && (
         <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '200px' }}>
           <CircularProgress />

--- a/packages/frontend/src/components/Content/MarkdownContent/MarkdownContent.tsx
+++ b/packages/frontend/src/components/Content/MarkdownContent/MarkdownContent.tsx
@@ -3,6 +3,7 @@ import { Box, Chip, Typography } from '@mui/material';
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useFrontmatter } from '../../../hooks/useFrontmatter';
+import useIsMobile from '../../../hooks/useIsMobile';
 import { useViewMode } from '../../../hooks/useViewMode';
 import { fetchContent } from '../../../store/slices/contentSlice';
 import { fetchDiff, fetchDiffPrev } from '../../../store/slices/diffSlice';
@@ -28,6 +29,7 @@ const MarkdownContent: React.FC<MarkdownContentProps> = ({ scrollToId, onDirecto
 
   const { frontmatter, markdownContent } = useFrontmatter(content);
   const viewMode = useViewMode();
+  const isMobile = useIsMobile();
   const loading = contentLoading || fileTreeLoading;
 
   useEffect(() => {
@@ -76,9 +78,9 @@ const MarkdownContent: React.FC<MarkdownContentProps> = ({ scrollToId, onDirecto
         minWidth: 0,
         minHeight: 'calc(100vh - 64px)',
         m: 0,
-        p: 4,
+        p: isMobile ? 2 : 4,
         bgcolor: 'background.paper',
-        ...(contentMode === 'compact' && {
+        ...(contentMode === 'compact' && !isMobile && {
           width: '800px',
           margin: '0 auto',
           borderRight: '1px solid',
@@ -89,8 +91,8 @@ const MarkdownContent: React.FC<MarkdownContentProps> = ({ scrollToId, onDirecto
     >
       <BreadCrumb onDirectorySelect={onDirectorySelect} />
       <Box sx={{ display: 'flex', alignItems: 'center', mb: 4 }}>
-        <ArticleOutlined sx={{ mr: 2 }} fontSize="large" />
-        <Typography variant="h4" gutterBottom sx={{ mb: 0 }}>
+        <ArticleOutlined sx={{ mr: 2 }} fontSize={isMobile ? 'medium' : 'large'} />
+        <Typography variant={isMobile ? 'h5' : 'h4'} gutterBottom sx={{ mb: 0, wordBreak: 'break-word' }}>
           {displayFileName}
         </Typography>
       </Box>

--- a/packages/frontend/src/components/Content/MarkdownContent/MarkdownContentTabs.tsx
+++ b/packages/frontend/src/components/Content/MarkdownContent/MarkdownContentTabs.tsx
@@ -2,6 +2,7 @@ import { Box, Tab, Tabs } from '@mui/material';
 import React, { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import { useSearchParams } from 'react-router-dom';
+import useIsMobile from '../../../hooks/useIsMobile';
 import { ViewMode } from '../../../hooks/useViewMode';
 import { RootState } from '../../../store/store';
 
@@ -14,6 +15,7 @@ const MarkdownContentTabs: React.FC<MarkdownContentTabsProps> = ({ viewMode, has
   const [searchParams, setSearchParams] = useSearchParams();
   const { isGitRepository } = useSelector((state: RootState) => state.fileTree);
   const { diff } = useSelector((state: RootState) => state.diff);
+  const isMobile = useIsMobile();
 
   const handleChange = useCallback((_: React.SyntheticEvent | null, newValue: ViewMode) => {
     searchParams.set('tab', newValue);
@@ -27,14 +29,21 @@ const MarkdownContentTabs: React.FC<MarkdownContentTabsProps> = ({ viewMode, has
   return (
     <Box
       sx={{
-        paddingLeft: '24px',
-        marginLeft: '-32px',
-        marginRight: '-32px',
+        paddingLeft: isMobile ? '8px' : '24px',
+        marginLeft: isMobile ? '-16px' : '-32px',
+        marginRight: isMobile ? '-16px' : '-32px',
         borderBottom: 1,
         borderColor: 'divider',
       }}
     >
-      <Tabs value={viewMode} onChange={handleChange} aria-label="view mode tabs">
+      <Tabs
+        value={viewMode}
+        onChange={handleChange}
+        aria-label="view mode tabs"
+        variant={isMobile ? 'scrollable' : 'standard'}
+        scrollButtons={isMobile ? 'auto' : false}
+        allowScrollButtonsMobile
+      >
         <Tab value="preview" label="Preview" onClick={handleClick} />
         {hasFrontmatter && <Tab value="frontmatter" label="Frontmatter" />}
         <Tab value="raw" label="Raw" />

--- a/packages/frontend/src/components/LeftPane/FileTree.tsx
+++ b/packages/frontend/src/components/LeftPane/FileTree.tsx
@@ -1,6 +1,7 @@
-import { Box, useTheme } from '@mui/material';
+import { Box, Drawer, useTheme } from '@mui/material';
 import React, { useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import useIsMobile from '../../hooks/useIsMobile';
 import {
   expandAllNodes,
   fetchFileTree,
@@ -23,6 +24,7 @@ interface FileTreeComponentProps {
 const FileTree: React.FC<FileTreeComponentProps> = ({ onFileSelect, isOpen, onToggle }) => {
   const dispatch = useDispatch<AppDispatch>();
   const theme = useTheme();
+  const isMobile = useIsMobile();
   const {
     fileTree,
     filteredFileTree,
@@ -85,41 +87,68 @@ const FileTree: React.FC<FileTreeComponentProps> = ({ onFileSelect, isOpen, onTo
   }, [searchQuery, filteredFileTree, dispatch]);
 
   const overlay = theme.palette.mode === 'dark' ? 'rgba(16, 16, 16, 0.01)' : 'rgba(192, 192, 192, 0.01)';
+  const background = `linear-gradient(135deg, ${overlay} 0%, ${theme.palette.background.paper} 100%)`;
 
-  return (
-    <Box sx={{
-      width: isOpen ? '300px' : '66px',
-      background: `linear-gradient(135deg, ${overlay} 0%, ${theme.palette.background.paper} 100%)`,
-      py: 2,
-      borderRight: '1px solid',
-      borderColor: 'divider',
-      minHeight: '100%',
-      flexShrink: 0,
-    }}>
+  const handleFileSelectWithClose = useCallback((path: string) => {
+    onFileSelect(path);
+    if (isMobile) onToggle();
+  }, [onFileSelect, isMobile, onToggle]);
+
+  const panelContent = (
+    <>
       <FileTreeHeader
-        isOpen={isOpen}
+        isOpen={isMobile ? true : isOpen}
         onToggle={onToggle}
         onExpandAllClick={handleExpandAllClick}
         onCollapseAll={handleCollapseAll}
       />
-      {isOpen && (
+      {(isMobile || isOpen) && (
         <FileTreeSearch
           searchQuery={searchQuery}
           onSearchChange={handleSearchChange}
           onClearSearch={handleClearSearch}
         />
       )}
-      {isOpen && (
+      {(isMobile || isOpen) && (
         <FileTreeContent
           filteredFileTree={filteredFileTree}
           loading={loading}
           error={error}
           expandedNodes={expandedNodes}
-          onFileSelect={onFileSelect}
+          onFileSelect={isMobile ? handleFileSelectWithClose : onFileSelect}
           onExpandedItemsChange={handleExpandedItemsChange}
           dispatch={dispatch}
         />
       )}
+    </>
+  );
+
+  if (isMobile) {
+    return (
+      <Drawer
+        variant="temporary"
+        anchor="left"
+        open={isOpen}
+        onClose={onToggle}
+        ModalProps={{ keepMounted: true }}
+        slotProps={{ paper: { sx: { width: '280px', bgcolor: 'background.paper', py: 2, borderRight: '1px solid', borderColor: 'divider' } } }}
+      >
+        {panelContent}
+      </Drawer>
+    );
+  }
+
+  return (
+    <Box sx={{
+      width: isOpen ? '300px' : '66px',
+      background,
+      py: 2,
+      borderRight: '1px solid',
+      borderColor: 'divider',
+      minHeight: '100%',
+      flexShrink: 0,
+    }}>
+      {panelContent}
     </Box>
   );
 };

--- a/packages/frontend/src/components/RightPane/Outline.tsx
+++ b/packages/frontend/src/components/RightPane/Outline.tsx
@@ -1,6 +1,7 @@
-import { Box, useTheme } from '@mui/material';
-import React, { useEffect } from 'react';
+import { Box, Drawer, useTheme } from '@mui/material';
+import React, { useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import useIsMobile from '../../hooks/useIsMobile';
 import { fetchOutline } from '../../store/slices/outlineSlice';
 import { AppDispatch, RootState } from '../../store/store';
 import OutlineContent from './OutlineContent/OutlineContent';
@@ -16,11 +17,46 @@ interface OutlineProps {
 const Outline: React.FC<OutlineProps> = ({ filePath, onItemClick, isOpen, onToggle }) => {
   const dispatch = useDispatch<AppDispatch>();
   const theme = useTheme();
+  const isMobile = useIsMobile();
   const { outline, loading, error } = useSelector((state: RootState) => state.outline);
 
   useEffect(() => {
     dispatch(fetchOutline(filePath));
   }, [dispatch, filePath]);
+
+  const handleItemClickWithClose = useCallback((id: string) => {
+    onItemClick(id);
+    if (isMobile) onToggle();
+  }, [onItemClick, isMobile, onToggle]);
+
+  const panelContent = (
+    <>
+      <OutlineHeader isOpen={isMobile ? true : isOpen} onToggle={onToggle} />
+      {(isMobile || isOpen) && (
+        <OutlineContent
+          outline={outline}
+          loading={loading}
+          error={error}
+          onItemClick={isMobile ? handleItemClickWithClose : onItemClick}
+        />
+      )}
+    </>
+  );
+
+  if (isMobile) {
+    return (
+      <Drawer
+        variant="temporary"
+        anchor="right"
+        open={isOpen}
+        onClose={onToggle}
+        ModalProps={{ keepMounted: true }}
+        slotProps={{ paper: { sx: { width: '280px', py: 2, background: theme.palette.background.paper, borderLeft: '1px solid', borderColor: 'divider' } } }}
+      >
+        {panelContent}
+      </Drawer>
+    );
+  }
 
   return (
     <Box sx={{
@@ -32,15 +68,7 @@ const Outline: React.FC<OutlineProps> = ({ filePath, onItemClick, isOpen, onTogg
       minHeight: '100%',
       flexShrink: 0,
     }}>
-      <OutlineHeader isOpen={isOpen} onToggle={onToggle} />
-      {isOpen && (
-        <OutlineContent
-          outline={outline}
-          loading={loading}
-          error={error}
-          onItemClick={onItemClick}
-        />
-      )}
+      {panelContent}
     </Box>
   );
 };

--- a/packages/frontend/src/components/SettingsDialog/SettingsDialog.tsx
+++ b/packages/frontend/src/components/SettingsDialog/SettingsDialog.tsx
@@ -1,11 +1,12 @@
 import { Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, Tab, Tabs, } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import React, { useCallback, useState } from 'react';
+import useIsMobile from '../../hooks/useIsMobile';
+import { useSettingsForm } from '../../hooks/useSettingsForm';
 import ColorSchemeSettingsTab from './ColorSchemeSettingsTab';
 import FontSettingsTab from './FontSettingsTab';
 import LayoutSettingsTab from './LayoutSettingsTab';
 import TabPanel from './TabPanel';
-import { useSettingsForm } from '../../hooks/useSettingsForm';
 
 interface SettingsDialogProps {
   open: boolean;
@@ -14,6 +15,7 @@ interface SettingsDialogProps {
 
 const SettingsDialog: React.FC<SettingsDialogProps> = ({ open, onClose }) => {
   const theme = useTheme();
+  const isMobile = useIsMobile();
   const [selectedTab, setSelectedTab] = useState(0);
 
   const {
@@ -57,17 +59,28 @@ const SettingsDialog: React.FC<SettingsDialogProps> = ({ open, onClose }) => {
   }, [setSelectedTab]);
 
   return (
-    <Dialog maxWidth='lg' open={open} onClose={onClose}>
+    <Dialog maxWidth='lg' open={open} onClose={onClose} fullScreen={isMobile}>
       <DialogTitle sx={{ pt: 2, pb: 2, borderBottom: '1px solid', borderColor: 'divider' }}>Appearance Settings</DialogTitle>
-      <DialogContent sx={{ width: 800, height: 600, p: 0 }} className="custom-scrollbar">
-        <Box sx={{ flexGrow: 1, display: 'flex', height: '100%' }}>
+      <DialogContent
+        sx={{
+          width: isMobile ? '100%' : 800,
+          height: isMobile ? '100%' : 600,
+          p: 0,
+        }}
+        className="custom-scrollbar"
+      >
+        <Box sx={{ flexGrow: 1, display: 'flex', flexDirection: isMobile ? 'column' : 'row', height: '100%' }}>
           <Tabs
-            orientation="vertical"
+            orientation={isMobile ? 'horizontal' : 'vertical'}
             variant="scrollable"
             value={selectedTab}
             onChange={handleSelectTab}
-            aria-label="Vertical tabs"
-            sx={{
+            aria-label={isMobile ? 'Horizontal tabs' : 'Vertical tabs'}
+            sx={isMobile ? {
+              borderBottom: 1,
+              borderColor: 'divider',
+              flexShrink: 0,
+            } : {
               minWidth: 200,
               py: 4,
               borderRight: 1,

--- a/packages/frontend/src/hooks/useIsMobile.ts
+++ b/packages/frontend/src/hooks/useIsMobile.ts
@@ -1,0 +1,8 @@
+import { useMediaQuery, useTheme } from '@mui/material';
+
+const useIsMobile = (): boolean => {
+  const theme = useTheme();
+  return useMediaQuery(theme.breakpoints.down('md'));
+};
+
+export default useIsMobile;

--- a/packages/frontend/test/unit/__snapshots__/Layout.test.tsx.snap
+++ b/packages/frontend/test/unit/__snapshots__/Layout.test.tsx.snap
@@ -366,7 +366,7 @@ exports[`Layout renders correctly 1`] = `
         class="MuiBox-root css-jv7lyf"
       >
         <div
-          class="custom-scrollbar MuiBox-root css-ynu778"
+          class="custom-scrollbar MuiBox-root css-z5visb"
         >
           <div
             class="MuiBox-root css-1t4r39b"
@@ -397,7 +397,7 @@ exports[`Layout renders correctly 1`] = `
                 />
               </svg>
               <h4
-                class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom css-129bu66-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom css-lsowdo-MuiTypography-root"
               >
                 🎉 Welcome to mdts!
               </h4>
@@ -406,7 +406,7 @@ exports[`Layout renders correctly 1`] = `
               class="MuiBox-root css-i3qfz4"
             >
               <div
-                class="MuiTabs-root css-jhczcq-MuiTabs-root"
+                class="MuiTabs-root css-1xkjjjh-MuiTabs-root"
               >
                 <div
                   class="MuiTabs-scroller MuiTabs-fixed css-s2t35c-MuiTabs-scroller"

--- a/packages/frontend/test/unit/components/Content/DirectoryContent/__snapshots__/DirectoryContent.test.tsx.snap
+++ b/packages/frontend/test/unit/components/Content/DirectoryContent/__snapshots__/DirectoryContent.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`DirectoryContent renders correctly with initial state 1`] = `
         />
       </svg>
       <h4
-        class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom css-129bu66-MuiTypography-root"
+        class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom css-lsowdo-MuiTypography-root"
       />
     </div>
     <hr

--- a/packages/frontend/test/unit/components/Content/MarkdownContent/__snapshots__/MarkdownContent.test.tsx.snap
+++ b/packages/frontend/test/unit/components/Content/MarkdownContent/__snapshots__/MarkdownContent.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`MarkdownContent renders welcome message when no file is selected 1`] = 
         />
       </svg>
       <h4
-        class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom css-129bu66-MuiTypography-root"
+        class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom css-lsowdo-MuiTypography-root"
       >
         🎉 Welcome to mdts!
       </h4>
@@ -40,7 +40,7 @@ exports[`MarkdownContent renders welcome message when no file is selected 1`] = 
       class="MuiBox-root css-i3qfz4"
     >
       <div
-        class="MuiTabs-root css-jhczcq-MuiTabs-root"
+        class="MuiTabs-root css-1xkjjjh-MuiTabs-root"
       >
         <div
           class="MuiTabs-scroller MuiTabs-fixed css-s2t35c-MuiTabs-scroller"

--- a/packages/frontend/test/unit/components/Content/MarkdownContent/__snapshots__/MarkdownContentTabs.test.tsx.snap
+++ b/packages/frontend/test/unit/components/Content/MarkdownContent/__snapshots__/MarkdownContentTabs.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`MarkdownContentTabs renders preview and raw tabs by default 1`] = `
     class="MuiBox-root css-i3qfz4"
   >
     <div
-      class="MuiTabs-root css-jhczcq-MuiTabs-root"
+      class="MuiTabs-root css-1xkjjjh-MuiTabs-root"
     >
       <div
         class="MuiTabs-scroller MuiTabs-fixed css-s2t35c-MuiTabs-scroller"

--- a/packages/frontend/test/unit/components/Content/__snapshots__/Content.test.tsx.snap
+++ b/packages/frontend/test/unit/components/Content/__snapshots__/Content.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Content renders correctly 1`] = `
     class="MuiBox-root css-jv7lyf"
   >
     <div
-      class="custom-scrollbar MuiBox-root css-ynu778"
+      class="custom-scrollbar MuiBox-root css-z5visb"
     >
       <div
         data-testid="mock-markdown-content"


### PR DESCRIPTION
Closes #657

## Summary
- FileTree / Outline render as temporary Drawers below the `md` breakpoint, auto-close on item click, mutually exclusive
- AppHeader gains hamburger / outline toggle on mobile; GitHub link and version label hidden to save space
- MarkdownContent / DirectoryContent tighten padding and heading size, disable compact-width cap on mobile
- MarkdownContentTabs switch to scrollable variant so many tabs still fit, negative margin follows reduced mobile padding
- SettingsDialog goes `fullScreen` with horizontal tabs on mobile
- Content box clamps horizontal overflow inside the scroll area to keep the page itself scroll-free

## Test plan
- [x] `npm run lint:frontend`
- [x] `npm run test:frontend` (254 tests / 42 snapshots)
- [x] Manual: 420×853 mobile viewport — drawers, auto-close, settings fullscreen, no horizontal page scroll (`html.scrollWidth === innerWidth`)
- [x] Manual: 1280×800 desktop viewport — layout unchanged, settings dialog unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced mobile responsiveness with adaptive layouts and typography across the app
  * Added mobile toggle controls for file tree and outline navigation panels
  * Improved settings dialog to display full-screen on mobile devices
  * Better content handling with improved horizontal scrolling and text wrapping support
  * Responsive spacing and sizing adjustments optimized for mobile viewing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->