### PR TITLE
test: improve test coverage across CLI, server, and frontend

### DIFF
--- a/packages/frontend/test/unit/App.behavior.test.tsx
+++ b/packages/frontend/test/unit/App.behavior.test.tsx
@@ -1,0 +1,127 @@
+import { createTheme } from '@mui/material';
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { Provider } from 'react-redux';
+import App from '../../src/App';
+import { saveAppSetting } from '../../src/store/slices/appSettingSlice';
+import { fetchConfig } from '../../src/store/slices/configSlice';
+import { fetchFileTree } from '../../src/store/slices/fileTreeSlice';
+import { updateHistoryFromLocation } from '../../src/store/slices/historySlice';
+import { useTheme } from '../../src/hooks/useTheme';
+import { useWebSocket } from '../../src/hooks/useWebSocket';
+import { createMockStore } from '../utils';
+
+const mockUseLocation = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useLocation: () => mockUseLocation(),
+}));
+
+jest.mock('../../src/hooks/useTheme', () => ({
+  useTheme: jest.fn(),
+}));
+
+jest.mock('../../src/hooks/useWebSocket', () => ({
+  useWebSocket: jest.fn(),
+}));
+
+jest.mock('../../src/Layout', () => ({
+  __esModule: true,
+  default: ({ onSettingsClick }: { onSettingsClick: () => void }) => (
+    <button type="button" onClick={onSettingsClick}>
+      open settings
+    </button>
+  ),
+}));
+
+jest.mock('../../src/components/SettingsDialog/SettingsDialog', () => ({
+  __esModule: true,
+  default: ({ open, onClose }: { open: boolean; onClose: () => void }) => (
+    <div>
+      <span data-testid="settings-dialog">{open ? 'open' : 'closed'}</span>
+      <button type="button" onClick={onClose}>
+        close settings
+      </button>
+    </div>
+  ),
+}));
+
+jest.mock('../../src/store/slices/configSlice', () => ({
+  fetchConfig: jest.fn(() => ({ type: 'config/fetchConfig/mock' })),
+}));
+
+jest.mock('../../src/store/slices/fileTreeSlice', () => ({
+  fetchFileTree: jest.fn(() => ({ type: 'fileTree/fetchFileTree/mock' })),
+}));
+
+jest.mock('../../src/store/slices/historySlice', () => ({
+  updateHistoryFromLocation: jest.fn((pathname: string) => ({
+    type: 'history/updateHistoryFromLocation/mock',
+    payload: pathname,
+  })),
+}));
+
+describe('App behavior', () => {
+  const mockedUseTheme = useTheme as jest.MockedFunction<typeof useTheme>;
+  const mockedUseWebSocket = useWebSocket as jest.MockedFunction<typeof useWebSocket>;
+  const mockedFetchConfig = fetchConfig as jest.MockedFunction<typeof fetchConfig>;
+  const mockedFetchFileTree = fetchFileTree as jest.MockedFunction<typeof fetchFileTree>;
+  const mockedUpdateHistoryFromLocation =
+    updateHistoryFromLocation as jest.MockedFunction<typeof updateHistoryFromLocation>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseLocation.mockReturnValue({ pathname: '/docs/readme.md' });
+    mockedUseTheme.mockReturnValue(createTheme());
+  });
+
+  const renderApp = (initialState = {}) => {
+    const store = createMockStore(initialState);
+
+    render(
+      <Provider store={store}>
+        <App />
+      </Provider>
+    );
+
+    return store;
+  };
+
+  test('opens and closes the settings dialog from layout actions', () => {
+    renderApp();
+
+    expect(screen.getByTestId('settings-dialog')).toHaveTextContent('closed');
+
+    fireEvent.click(screen.getByRole('button', { name: 'open settings' }));
+    expect(screen.getByTestId('settings-dialog')).toHaveTextContent('open');
+
+    fireEvent.click(screen.getByRole('button', { name: 'close settings' }));
+    expect(screen.getByTestId('settings-dialog')).toHaveTextContent('closed');
+  });
+
+  test('dispatches fallback settings when dark mode is invalid', () => {
+    const store = renderApp({
+      appSetting: {
+        darkMode: 'broken',
+        contentMode: 'full',
+      },
+      config: {
+        fontSize: 15,
+      },
+      history: {
+        currentPath: '/docs/readme.md',
+      },
+    });
+
+    expect(mockedUseWebSocket).toHaveBeenCalledWith('/docs/readme.md');
+    expect(mockedFetchFileTree).toHaveBeenCalledTimes(1);
+    expect(mockedFetchConfig).toHaveBeenCalledTimes(1);
+    expect(mockedUpdateHistoryFromLocation).toHaveBeenCalledWith('/docs/readme.md');
+    expect(document.documentElement.style.fontSize).toBe('17px');
+
+    expect(store.getActions()).toContainEqual(
+      saveAppSetting({ darkMode: 'auto', contentMode: 'compact' })
+    );
+  });
+});

--- a/packages/frontend/test/unit/App.test.tsx
+++ b/packages/frontend/test/unit/App.test.tsx
@@ -7,8 +7,8 @@ import { createMockStore } from '../utils';
 
 jest.mock('@mui/material', () => ({
   ...jest.requireActual('@mui/material'),
-  CssBaseline: () => null, // Mock CssBaseline to render nothing
-  AppBar: ({ children, ...props }: { children: React.ReactNode }) => <div {...props}>{children}</div>, // Mock AppBar
+  CssBaseline: () => null,
+  AppBar: ({ children, ...props }: { children: React.ReactNode }) => <div {...props}>{children}</div>,
 }));
 
 jest.mock('@mui/x-tree-view', () => ({
@@ -20,11 +20,9 @@ jest.mock('@mui/x-tree-view', () => ({
   ),
 }));
 
-// Mock the useFileTree hook
 jest.mock('../../src/api', () => ({
   fetchData: jest.fn(() => Promise.resolve([])),
 }));
-
 
 describe('App', () => {
   let store;
@@ -43,6 +41,7 @@ describe('App', () => {
         </Provider>
       );
     });
+
     expect(screen.getByRole('main')).toBeInTheDocument();
   });
 });

--- a/packages/frontend/test/unit/Layout.test.tsx
+++ b/packages/frontend/test/unit/Layout.test.tsx
@@ -1,126 +1,262 @@
-import { act, render, screen, fireEvent } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import { Provider } from 'react-redux';
-import { BrowserRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 import Layout from '../../src/Layout';
 import { toggleFileTree, toggleOutline } from '../../src/store/slices/appSettingSlice';
 import { createMockStore } from '../utils';
 
-jest.mock('@mui/x-tree-view', () => ({
-  ...jest.requireActual('@mui/x-tree-view'),
-  SimpleTreeView: ({ children, ...props }: { children: React.ReactNode }) => (
-    <div data-testid="mock-simple-tree-view" {...props}>
-      {children}
-    </div>
-  ),
-}));
-
-// Mock react-router-dom's useNavigate
 const mockNavigate = jest.fn();
+const mockUseIsMobile = jest.fn();
+
+type AppHeaderMockProps = {
+  handleFileSelect: (path: string) => void;
+  onSettingsClick: () => void;
+  onToggleFileTree: () => void;
+  onToggleOutline: () => void;
+};
+
+type ContentMockProps = {
+  onFileSelect: (path: string) => void;
+  onDirectorySelect: (path: string) => void;
+  scrollToId: string | null;
+};
+
+type FileTreeMockProps = {
+  isOpen: boolean;
+  onFileSelect: (path: string) => void;
+  selectedFilePath: string | null;
+};
+
+type OutlineMockProps = {
+  filePath: string | null;
+  isOpen: boolean;
+  onItemClick: (id: string) => void;
+};
+
+let mockAppHeaderProps: AppHeaderMockProps;
+let mockContentProps: ContentMockProps;
+let mockFileTreeProps: FileTreeMockProps;
+let mockOutlineProps: OutlineMockProps;
+
+function mockHandleHeaderFileSelect() {
+  mockAppHeaderProps.handleFileSelect('docs/readme.md');
+}
+
+function mockHandleContentFileSelect() {
+  mockContentProps.onFileSelect('content/file.md');
+}
+
+function mockHandleContentDirectorySelect() {
+  mockContentProps.onDirectorySelect('guides');
+}
+
+function mockHandleTreeFileSelect() {
+  mockFileTreeProps.onFileSelect('tree/file.md');
+}
+
+function mockHandleOutlineItemClick() {
+  mockOutlineProps.onItemClick('heading-1');
+}
+
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useNavigate: () => mockNavigate,
 }));
 
-// Mock appSettingSlice actions
-jest.mock('../../src/store/slices/appSettingSlice', () => ({
-  ...jest.requireActual('../../src/store/slices/appSettingSlice'),
-  toggleFileTree: jest.fn(() => ({ type: 'appSetting/toggleFileTree' })),
-  toggleOutline: jest.fn(() => ({ type: 'appSetting/toggleOutline' })),
+jest.mock('../../src/hooks/useIsMobile', () => ({
+  __esModule: true,
+  default: () => mockUseIsMobile(),
+}));
+
+jest.mock('../../src/components/AppHeader', () => ({
+  __esModule: true,
+  default: (props: AppHeaderMockProps) => {
+    mockAppHeaderProps = props;
+
+    return (
+      <div>
+        <button onClick={mockHandleHeaderFileSelect}>header-file-select</button>
+        <button onClick={props.onSettingsClick}>settings</button>
+        <button aria-label="toggle file tree" onClick={props.onToggleFileTree}>toggle file tree</button>
+        <button aria-label="toggle outline" onClick={props.onToggleOutline}>toggle outline</button>
+      </div>
+    );
+  },
+}));
+
+jest.mock('../../src/components/Content/Content', () => ({
+  __esModule: true,
+  default: (props: ContentMockProps) => {
+    mockContentProps = props;
+
+    return (
+      <div>
+        <div data-testid="content-scroll-id">{props.scrollToId ?? 'null'}</div>
+        <button onClick={mockHandleContentFileSelect}>content-file-select</button>
+        <button onClick={mockHandleContentDirectorySelect}>content-directory-select</button>
+      </div>
+    );
+  },
+}));
+
+jest.mock('../../src/components/LeftPane/FileTree', () => ({
+  __esModule: true,
+  default: (props: FileTreeMockProps) => {
+    mockFileTreeProps = props;
+
+    return (
+      <div>
+        <div data-testid="file-tree-open">{String(props.isOpen)}</div>
+        <div data-testid="selected-file-path">{props.selectedFilePath ?? 'null'}</div>
+        <button onClick={mockHandleTreeFileSelect}>tree-file-select</button>
+      </div>
+    );
+  },
+}));
+
+jest.mock('../../src/components/RightPane/Outline', () => ({
+  __esModule: true,
+  default: (props: OutlineMockProps) => {
+    mockOutlineProps = props;
+
+    return (
+      <div>
+        <div data-testid="outline-file-path">{props.filePath ?? 'null'}</div>
+        <div data-testid="outline-open">{String(props.isOpen)}</div>
+        <button onClick={mockHandleOutlineItemClick}>outline-item-click</button>
+      </div>
+    );
+  },
 }));
 
 describe('Layout', () => {
-  let store;
+  const renderLayout = (
+    initialState = {},
+    onSettingsClick = jest.fn(),
+  ) => {
+    const store = createMockStore(initialState);
+    store.dispatch = jest.fn();
+
+    return {
+      ...render(
+        <Provider store={store}>
+          <MemoryRouter>
+            <Layout onSettingsClick={onSettingsClick} />
+          </MemoryRouter>
+        </Provider>
+      ),
+      onSettingsClick,
+      store,
+    };
+  };
 
   beforeEach(() => {
-    store = createMockStore();
-    store.dispatch = jest.fn();
+    mockNavigate.mockClear();
+    mockUseIsMobile.mockReturnValue(false);
+    document.documentElement.style.removeProperty('--markdown-font-family');
+    document.documentElement.style.removeProperty('--markdown-monospace-font-family');
   });
 
-  test('renders correctly', async () => {
-    let asFragment;
-    await act(async () => {
-      const { asFragment: f } = render(
-        <Provider store={store}>
-          <BrowserRouter>
-            <Layout />
-          </BrowserRouter>
-        </Provider>
-      );
-      asFragment = f;
+  test('renders correctly', () => {
+    const { asFragment } = renderLayout({
+      history: { currentPath: 'docs/readme.md', isDirectory: false },
     });
+
     expect(asFragment()).toMatchSnapshot();
   });
 
-  test('handleFileSelect navigates to the correct path', async () => {
-    await act(async () => {
-      render(
-        <Provider store={store}>
-          <BrowserRouter>
-            <Layout />
-          </BrowserRouter>
-        </Provider>
-      );
-    });
+  test('navigates from child callbacks and applies font variables', () => {
+    const onSettingsClick = jest.fn();
 
-    // Simulate a file selection from AppHeader (logo click)
-    fireEvent.click(screen.getByText('mdts'));
-    expect(mockNavigate).toHaveBeenCalledWith('/');
+    renderLayout({
+      config: {
+        fontFamily: 'Fira Sans',
+        fontFamilyMonospace: 'Fira Code',
+      },
+      history: { currentPath: 'docs/readme.md', isDirectory: false },
+    }, onSettingsClick);
+
+    fireEvent.click(screen.getByText('header-file-select'));
+    fireEvent.click(screen.getByText('tree-file-select'));
+    fireEvent.click(screen.getByText('content-directory-select'));
+    fireEvent.click(screen.getByText('settings'));
+
+    expect(mockNavigate).toHaveBeenNthCalledWith(1, '/docs/readme.md');
+    expect(mockNavigate).toHaveBeenNthCalledWith(2, '/tree/file.md');
+    expect(mockNavigate).toHaveBeenNthCalledWith(3, '/guides');
+    expect(onSettingsClick).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('selected-file-path')).toHaveTextContent('docs/readme.md');
+    expect(screen.getByTestId('outline-file-path')).toHaveTextContent('docs/readme.md');
+    expect(document.documentElement.style.getPropertyValue('--markdown-font-family')).toBe('Fira Sans');
+    expect(document.documentElement.style.getPropertyValue('--markdown-monospace-font-family')).toBe('Fira Code');
   });
 
-  test('handleToggleFileTree dispatches toggleFileTree', async () => {
-    await act(async () => {
-      render(
-        <Provider store={store}>
-          <BrowserRouter>
-            <Layout />
-          </BrowserRouter>
-        </Provider>
-      );
+  test('passes null outline file path for directories and updates scroll target', () => {
+    renderLayout({
+      history: { currentPath: 'docs', isDirectory: true },
+    });
+
+    expect(screen.getByTestId('outline-file-path')).toHaveTextContent('null');
+    expect(screen.getByTestId('content-scroll-id')).toHaveTextContent('null');
+
+    fireEvent.click(screen.getByText('outline-item-click'));
+
+    expect(screen.getByTestId('content-scroll-id')).toHaveTextContent('heading-1');
+  });
+
+  test('dispatches desktop toggle actions', () => {
+    const { store } = renderLayout();
+
+    fireEvent.click(screen.getByLabelText('toggle file tree'));
+    fireEvent.click(screen.getByLabelText('toggle outline'));
+
+    expect(store.dispatch).toHaveBeenNthCalledWith(1, toggleFileTree());
+    expect(store.dispatch).toHaveBeenNthCalledWith(2, toggleOutline());
+    expect(screen.getByTestId('file-tree-open')).toHaveTextContent('true');
+    expect(screen.getByTestId('outline-open')).toHaveTextContent('true');
+  });
+
+  test('uses local mobile panel state and resets it after returning from desktop', () => {
+    mockUseIsMobile.mockReturnValue(true);
+
+    const { rerender, store } = renderLayout({
+      appSetting: {
+        fileTreeOpen: false,
+        outlineOpen: false,
+      },
     });
 
     fireEvent.click(screen.getByLabelText('toggle file tree'));
-    expect(store.dispatch).toHaveBeenCalledWith(toggleFileTree());
-  });
 
-  test('handleDirectorySelect navigates to the correct path', async () => {
-    await act(async () => {
-      render(
-        <Provider store={store}>
-          <BrowserRouter>
-            <Layout />
-          </BrowserRouter>
-        </Provider>
-      );
-    });
-
-    // This requires simulating a directory selection from the Content component.
-    // Since Content is mocked, we'll simulate the prop being called.
-    // For a more robust test, we'd need to render Content and simulate interaction there.
-    // For now, we'll rely on the fact that handleDirectorySelect is passed down.
-
-    // This part is tricky without directly interacting with the Content component.
-    // We'll assume the prop is correctly passed and focus on the navigation.
-    // The actual interaction would happen in DirectoryContent.test.tsx
-  });
-
-  test('handleOutlineItemClick sets scrollToId', async () => {
-    // This is an internal state change, difficult to test directly without exposing state.
-    // We'll rely on the Outline component's tests to ensure onItemClick is called correctly.
-  });
-
-  test('handleToggleOutline dispatches toggleOutline', async () => {
-    await act(async () => {
-      render(
-        <Provider store={store}>
-          <BrowserRouter>
-            <Layout />
-          </BrowserRouter>
-        </Provider>
-      );
-    });
+    expect(screen.getByTestId('file-tree-open')).toHaveTextContent('true');
+    expect(screen.getByTestId('outline-open')).toHaveTextContent('false');
 
     fireEvent.click(screen.getByLabelText('toggle outline'));
-    expect(store.dispatch).toHaveBeenCalledWith(toggleOutline());
+
+    expect(screen.getByTestId('file-tree-open')).toHaveTextContent('false');
+    expect(screen.getByTestId('outline-open')).toHaveTextContent('true');
+    expect(store.dispatch).not.toHaveBeenCalled();
+
+    mockUseIsMobile.mockReturnValue(false);
+    rerender(
+      <Provider store={store}>
+        <MemoryRouter>
+          <Layout onSettingsClick={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    mockUseIsMobile.mockReturnValue(true);
+    rerender(
+      <Provider store={store}>
+        <MemoryRouter>
+          <Layout onSettingsClick={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(screen.getByTestId('file-tree-open')).toHaveTextContent('false');
+    expect(screen.getByTestId('outline-open')).toHaveTextContent('false');
   });
 });

--- a/packages/frontend/test/unit/__snapshots__/Layout.test.tsx.snap
+++ b/packages/frontend/test/unit/__snapshots__/Layout.test.tsx.snap
@@ -5,500 +5,69 @@ exports[`Layout renders correctly 1`] = `
   <div
     class="MuiBox-root css-s92abg"
   >
-    <header
-      class="MuiPaper-root MuiPaper-elevation MuiPaper-elevation0 MuiAppBar-root MuiAppBar-colorPrimary MuiAppBar-positionStatic css-83mobe-MuiPaper-root-MuiAppBar-root"
-      style="--Paper-shadow: none;"
-    >
-      <div
-        class="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular css-1ygil4i-MuiToolbar-root"
+    <div>
+      <button>
+        header-file-select
+      </button>
+      <button>
+        settings
+      </button>
+      <button
+        aria-label="toggle file tree"
       >
-        <div
-          class="MuiBox-root css-1xvvp3o"
-        >
-          <button
-            aria-label="Top page"
-            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeMedium css-1vqxir3-MuiButtonBase-root-MuiIconButton-root"
-            data-mui-internal-clone-element="true"
-            tabindex="0"
-            type="button"
-          >
-            <div
-              style="height: 56px; margin-top: -8px; margin-left: -16px;"
-            >
-              <svg
-                style="width: auto; height: 100%;"
-                viewBox="0 0 180 100"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <defs>
-                  <lineargradient
-                    id="grad"
-                    x1="0"
-                    x2="1"
-                    y1="0"
-                    y2="1"
-                  >
-                    <stop
-                      offset="0%"
-                      stop-color="#1976d2"
-                    />
-                    <stop
-                      offset="100%"
-                      stop-color="#1976d2"
-                    />
-                  </lineargradient>
-                  <style>
-                    
-            .logo-text {
-              font-family: 'Segoe UI', 'Arial', sans-serif;
-              font-size: 42px;
-              font-weight: 700;
-              fill: url(#grad);
-              letter-spacing: 2px;
-            }
-            .logo-icon {
-              fill: url(#grad);
-            }
-          
-                  </style>
-                </defs>
-                <g
-                  class="logo-icon"
-                  transform="translate(10, 20)"
-                >
-                  <path
-                    d="M5 25 L15 45"
-                    stroke="url(#grad)"
-                    stroke-width="2"
-                  />
-                  <path
-                    d="M25 25 L15 45"
-                    stroke="url(#grad)"
-                    stroke-width="2"
-                  />
-                  <rect
-                    height="10"
-                    rx="2"
-                    width="10"
-                    x="0"
-                    y="20"
-                  />
-                  <rect
-                    height="10"
-                    rx="2"
-                    width="10"
-                    x="20"
-                    y="20"
-                  />
-                  <rect
-                    height="10"
-                    rx="2"
-                    width="10"
-                    x="10"
-                    y="40"
-                  />
-                </g>
-                <text
-                  class="logo-text"
-                  x="60"
-                  y="70"
-                >
-                  mdts
-                </text>
-              </svg>
-            </div>
-          </button>
-        </div>
-        <button
-          aria-label="Settings"
-          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeMedium css-v8k5r1-MuiButtonBase-root-MuiIconButton-root"
-          data-mui-internal-clone-element="true"
-          tabindex="0"
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
-            data-testid="SettingsIcon"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58c.18-.14.23-.41.12-.61l-1.92-3.32c-.12-.22-.37-.29-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54c-.04-.24-.24-.41-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.05.3-.09.63-.09.94s.02.64.07.94l-2.03 1.58c-.18.14-.23.41-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6"
-            />
-          </svg>
-        </button>
-        <a
-          aria-label="GitHub Repository"
-          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeMedium css-v8k5r1-MuiButtonBase-root-MuiIconButton-root"
-          data-mui-internal-clone-element="true"
-          href="https://github.com/unhappychoice/mdts"
-          rel="noopener"
-          tabindex="0"
-          target="_blank"
-        >
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
-            data-testid="GitHubIcon"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M12 1.27a11 11 0 00-3.48 21.46c.55.09.73-.28.73-.55v-1.84c-3.03.64-3.67-1.46-3.67-1.46-.55-1.29-1.28-1.65-1.28-1.65-.92-.65.1-.65.1-.65 1.1 0 1.73 1.1 1.73 1.1.92 1.65 2.57 1.2 3.21.92a2 2 0 01.64-1.47c-2.47-.27-5.04-1.19-5.04-5.5 0-1.1.46-2.1 1.2-2.84a3.76 3.76 0 010-2.93s.91-.28 3.11 1.1c1.8-.49 3.7-.49 5.5 0 2.1-1.38 3.02-1.1 3.02-1.1a3.76 3.76 0 010 2.93c.83.74 1.2 1.74 1.2 2.94 0 4.21-2.57 5.13-5.04 5.4.45.37.82.92.82 2.02v3.03c0 .27.1.64.73.55A11 11 0 0012 1.27"
-            />
-          </svg>
-        </a>
-        <div
-          class="MuiBox-root css-gcae57"
-        >
-          <a
-            aria-label="Changelog"
-            class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1orsvah-MuiTypography-root-MuiLink-root"
-            data-mui-internal-clone-element="true"
-            href="https://github.com/unhappychoice/mdts/blob/main/CHANGELOG.md"
-            rel="noopener"
-            target="_blank"
-          >
-            v
-          </a>
-        </div>
-      </div>
-    </header>
+        toggle file tree
+      </button>
+      <button
+        aria-label="toggle outline"
+      >
+        toggle outline
+      </button>
+    </div>
     <main
       class="MuiBox-root css-1b2sp54"
     >
-      <div
-        class="MuiBox-root css-9681nh"
-      >
+      <div>
         <div
-          class="MuiBox-root css-xonpca"
+          data-testid="file-tree-open"
         >
-          <div
-            class="MuiBox-root css-1g3qtqm"
-          >
-            <h6
-              class="MuiTypography-root MuiTypography-h6 MuiTypography-gutterBottom css-1b6r7r0-MuiTypography-root"
-            >
-              File Tree
-            </h6>
-            <button
-              aria-label="expand all"
-              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-155wbr6-MuiButtonBase-root-MuiIconButton-root"
-              tabindex="0"
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
-                data-testid="UnfoldMoreIcon"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M12 5.83 15.17 9l1.41-1.41L12 3 7.41 7.59 8.83 9zm0 12.34L8.83 15l-1.41 1.41L12 21l4.59-4.59L15.17 15z"
-                />
-              </svg>
-            </button>
-            <button
-              aria-label="collapse all"
-              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-155wbr6-MuiButtonBase-root-MuiIconButton-root"
-              tabindex="0"
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
-                data-testid="UnfoldLessIcon"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M7.41 18.59 8.83 20 12 16.83 15.17 20l1.41-1.41L12 14zm9.18-13.18L15.17 4 12 7.17 8.83 4 7.41 5.41 12 10z"
-                />
-              </svg>
-            </button>
-          </div>
-          <button
-            aria-label="toggle file tree"
-            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1nyqon6-MuiButtonBase-root-MuiIconButton-root"
-            tabindex="0"
-            type="button"
-          >
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
-              data-testid="ChevronLeftIcon"
-              focusable="false"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"
-              />
-            </svg>
-          </button>
+          true
         </div>
         <div
-          class="MuiBox-root css-0"
-          mb="2"
-          px="2"
+          data-testid="selected-file-path"
         >
-          <div
-            class="MuiInputBase-root MuiInputBase-colorPrimary css-pe16f2-MuiInputBase-root"
-          >
-            <input
-              aria-label="search files"
-              class="MuiInputBase-input css-e77w8q-MuiInputBase-input"
-              placeholder="Search files..."
-              type="text"
-              value=""
-            />
-          </div>
+          docs/readme.md
         </div>
-        <ul
-          aria-multiselectable="false"
-          class="custom-scrollbar MuiSimpleTreeView-root css-5c3a1o-MuiSimpleTreeView-root"
-          defaultcollapseicon="[object Object]"
-          defaultexpandicon="[object Object]"
-          id="mui-tree-view-1"
-          role="tree"
-          style="--TreeView-itemChildrenIndentation: 12px;"
-        >
-          <li
-            aria-checked="false"
-            class="MuiTreeItem-root MuiSimpleTreeView-root css-jq3mgl-MuiTreeItem-root"
-            id="mui-tree-view-1-test.md"
-            role="treeitem"
-            style="--TreeView-itemDepth: 0;"
-            tabindex="0"
-          >
-            <div
-              class="MuiTreeItem-content MuiSimpleTreeView-itemContent css-lz1n60-MuiTreeItem-content"
-            >
-              <div
-                class="MuiTreeItem-iconContainer MuiSimpleTreeView-itemIconContainer css-bt3rqe-MuiTreeItem-iconContainer"
-              />
-              <div
-                class="MuiTreeItem-label MuiSimpleTreeView-itemLabel css-1yq7dn0-MuiTreeItem-label"
-              >
-                <div
-                  class="MuiBox-root css-70qvj9"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-eep7r1-MuiSvgIcon-root"
-                    data-testid="ArticleOutlinedIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M19 5v14H5V5zm0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2"
-                    />
-                    <path
-                      d="M14 17H7v-2h7zm3-4H7v-2h10zm0-4H7V7h10z"
-                    />
-                  </svg>
-                  <p
-                    class="MuiTypography-root MuiTypography-body2 css-1q85b70-MuiTypography-root"
-                  >
-                    test.md
-                  </p>
-                </div>
-              </div>
-            </div>
-          </li>
-          <li
-            aria-checked="false"
-            aria-expanded="false"
-            class="MuiTreeItem-root MuiSimpleTreeView-root css-jq3mgl-MuiTreeItem-root"
-            id="mui-tree-view-1-folder"
-            role="treeitem"
-            style="--TreeView-itemDepth: 0;"
-            tabindex="-1"
-          >
-            <div
-              class="MuiTreeItem-content MuiSimpleTreeView-itemContent css-lz1n60-MuiTreeItem-content"
-            >
-              <div
-                class="MuiTreeItem-iconContainer MuiSimpleTreeView-itemIconContainer css-bt3rqe-MuiTreeItem-iconContainer"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
-                  data-testid="TreeViewExpandIconIcon"
-                  focusable="false"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="M10 6 8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
-                  />
-                </svg>
-              </div>
-              <div
-                class="MuiTreeItem-label MuiSimpleTreeView-itemLabel css-1yq7dn0-MuiTreeItem-label"
-              >
-                <div
-                  class="MuiBox-root css-70qvj9"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-colorPrimary MuiSvgIcon-fontSizeMedium css-muidwl-MuiSvgIcon-root"
-                    data-testid="FolderOutlinedIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="m9.17 6 2 2H20v10H4V6zM10 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2h-8z"
-                    />
-                  </svg>
-                  <p
-                    class="MuiTypography-root MuiTypography-body2 css-1jo9ady-MuiTypography-root"
-                  >
-                    folder
-                  </p>
-                </div>
-              </div>
-            </div>
-          </li>
-        </ul>
+        <button>
+          tree-file-select
+        </button>
       </div>
-      <div
-        class="MuiBox-root css-jv7lyf"
-      >
+      <div>
         <div
-          class="custom-scrollbar MuiBox-root css-z5visb"
+          data-testid="content-scroll-id"
         >
-          <div
-            class="MuiBox-root css-1t4r39b"
-          >
-            <nav
-              aria-label="breadcrumb"
-              class="MuiTypography-root MuiTypography-body1 MuiBreadcrumbs-root css-1eq4jhp-MuiTypography-root-MuiBreadcrumbs-root"
-            >
-              <ol
-                class="MuiBreadcrumbs-ol css-1uwp4ue-MuiBreadcrumbs-ol"
-              />
-            </nav>
-            <div
-              class="MuiBox-root css-1ol10sz"
-            >
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge css-1oa9u9i-MuiSvgIcon-root"
-                data-testid="ArticleOutlinedIcon"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M19 5v14H5V5zm0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2"
-                />
-                <path
-                  d="M14 17H7v-2h7zm3-4H7v-2h10zm0-4H7V7h10z"
-                />
-              </svg>
-              <h4
-                class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom css-lsowdo-MuiTypography-root"
-              >
-                🎉 Welcome to mdts!
-              </h4>
-            </div>
-            <div
-              class="MuiBox-root css-i3qfz4"
-            >
-              <div
-                class="MuiTabs-root css-1xkjjjh-MuiTabs-root"
-              >
-                <div
-                  class="MuiTabs-scroller MuiTabs-fixed css-s2t35c-MuiTabs-scroller"
-                  style="overflow: hidden; margin-bottom: 0px;"
-                >
-                  <div
-                    aria-label="view mode tabs"
-                    class="MuiTabs-list css-hzcega-MuiTabs-list"
-                    role="tablist"
-                  >
-                    <button
-                      aria-selected="true"
-                      class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary Mui-selected css-mobu7h-MuiButtonBase-root-MuiTab-root"
-                      role="tab"
-                      tabindex="0"
-                      type="button"
-                    >
-                      Preview
-                    </button>
-                    <button
-                      aria-selected="false"
-                      class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-mobu7h-MuiButtonBase-root-MuiTab-root"
-                      role="tab"
-                      tabindex="-1"
-                      type="button"
-                    >
-                      Raw
-                    </button>
-                    <button
-                      aria-selected="false"
-                      class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-mobu7h-MuiButtonBase-root-MuiTab-root"
-                      role="tab"
-                      tabindex="-1"
-                      type="button"
-                    >
-                      Last Commit
-                    </button>
-                  </div>
-                  <span
-                    class="MuiTabs-indicator css-1qltlow-MuiTabs-indicator"
-                    style="left: 0px; width: 0px;"
-                  />
-                </div>
-              </div>
-            </div>
-            <div
-              class="MuiBox-root css-hk7m0v"
-            >
-              <div
-                class="markdown-body MuiBox-root css-1yyviwt"
-              >
-                <div
-                  data-testid="mock-react-markdown"
-                />
-              </div>
-            </div>
-          </div>
+          null
         </div>
+        <button>
+          content-file-select
+        </button>
+        <button>
+          content-directory-select
+        </button>
       </div>
-      <div
-        class="MuiBox-root css-fm7iwp"
-      >
+      <div>
         <div
-          class="MuiBox-root css-mzwsmu"
+          data-testid="outline-file-path"
         >
-          <button
-            aria-label="toggle outline"
-            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1nyqon6-MuiButtonBase-root-MuiIconButton-root"
-            tabindex="0"
-            type="button"
-          >
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
-              data-testid="ChevronRightIcon"
-              focusable="false"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M10 6 8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
-              />
-            </svg>
-          </button>
-          <h6
-            class="MuiTypography-root MuiTypography-h6 MuiTypography-gutterBottom css-onjnbs-MuiTypography-root"
-          >
-            Outline
-          </h6>
+          docs/readme.md
         </div>
-        <ul
-          class="MuiList-root MuiList-padding MuiList-dense custom-scrollbar css-18l7s16-MuiList-root"
-        />
+        <div
+          data-testid="outline-open"
+        >
+          true
+        </div>
+        <button>
+          outline-item-click
+        </button>
       </div>
     </main>
   </div>

--- a/packages/frontend/test/unit/api.test.ts
+++ b/packages/frontend/test/unit/api.test.ts
@@ -1,0 +1,62 @@
+import { fetchData } from '../../src/api';
+
+const mockFetch = global.fetch as jest.MockedFunction<typeof fetch>;
+
+const createResponse = ({
+  ok = true,
+  status = 200,
+  json = undefined,
+  text = '',
+}: {
+  ok?: boolean;
+  status?: number;
+  json?: unknown;
+  text?: string;
+}) => ({
+  ok,
+  status,
+  json: jest.fn().mockResolvedValue(json),
+  text: jest.fn().mockResolvedValue(text),
+}) as unknown as Response;
+
+describe('fetchData', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns parsed json when responseType is json', async () => {
+    const payload = { value: 'test' };
+    mockFetch.mockResolvedValueOnce(createResponse({ json: payload }));
+
+    await expect(fetchData<typeof payload>('/api/config', 'json')).resolves.toEqual(payload);
+    expect(mockFetch).toHaveBeenCalledWith('/api/config');
+  });
+
+  it('returns text when responseType is text', async () => {
+    mockFetch.mockResolvedValueOnce(createResponse({ text: 'diff content' }));
+
+    await expect(fetchData<string>('/api/diff/test.md', 'text')).resolves.toBe('diff content');
+  });
+
+  it('logs and rethrows http errors', async () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    mockFetch.mockResolvedValueOnce(createResponse({ ok: false, status: 500 }));
+
+    await expect(fetchData('/api/config', 'json')).rejects.toThrow('HTTP error! status: 500');
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Error fetching from /api/config:',
+      expect.any(Error),
+    );
+  });
+
+  it('logs and rethrows fetch failures', async () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const error = new Error('Network down');
+
+    mockFetch.mockRejectedValueOnce(error);
+
+    await expect(fetchData('/api/config', 'json')).rejects.toThrow(error);
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Error fetching from /api/config:', error);
+  });
+});

--- a/packages/frontend/test/unit/components/Content/MarkdownContent/MarkdownContent.test.tsx
+++ b/packages/frontend/test/unit/components/Content/MarkdownContent/MarkdownContent.test.tsx
@@ -1,7 +1,7 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import { Provider } from 'react-redux';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter, MemoryRouter } from 'react-router-dom';
 import configureStore from 'redux-mock-store';
 import { thunk } from 'redux-thunk';
 import MarkdownContent from '../../../../../src/components/Content/MarkdownContent/MarkdownContent';
@@ -358,5 +358,65 @@ describe('MarkdownContent', () => {
 
     await screen.findByText('Test Heading');
     expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: 'smooth', block: 'start' });
+  });
+
+  test('renders tag and category chips and fetches previous diff in diff-prev mode', async () => {
+    const contentWithMetadata = [
+      '---',
+      'title: Release Notes',
+      'tags:',
+      '  - alpha',
+      '  - beta',
+      'categories:',
+      '  - docs',
+      '  - guides',
+      '---',
+      '# Markdown Content',
+    ].join('\n');
+
+    store = mockStore({
+      content: {
+        content: contentWithMetadata,
+        loading: false,
+        error: null,
+      },
+      diff: defaultDiffState,
+      fileTree: {
+        loading: false,
+        isGitRepository: true,
+      },
+      history: {
+        currentPath: '/path/to/test.md',
+        isDirectory: false,
+      },
+      appSetting: {
+        contentMode: 'compact',
+      },
+      config: {
+        fontFamily: 'Roboto',
+        fontFamilyMonospace: 'monospace',
+        fontSize: 14,
+      }
+    });
+
+    await act(async () => {
+      render(
+        <Provider store={store}>
+          <MemoryRouter initialEntries={['/?tab=diff-prev']}>
+            <MarkdownContent scrollToId={null} />
+          </MemoryRouter>
+        </Provider>
+      );
+    });
+
+    expect(screen.getByRole('heading', { name: 'Release Notes' })).toBeInTheDocument();
+    ['alpha', 'beta', 'docs', 'guides'].forEach((value) => {
+      expect(screen.getByText(value)).toBeInTheDocument();
+    });
+    expect(store.getActions()).toEqual([
+      { type: 'content/fetchContent', payload: '/path/to/test.md' },
+      { type: 'diff/fetchDiff', payload: '/path/to/test.md' },
+      { type: 'diff/fetchDiffPrev', payload: '/path/to/test.md' },
+    ]);
   });
 });

--- a/packages/frontend/test/unit/components/Content/MarkdownContent/MarkdownRenderer/MarkdownCode.test.tsx
+++ b/packages/frontend/test/unit/components/Content/MarkdownContent/MarkdownRenderer/MarkdownCode.test.tsx
@@ -1,10 +1,17 @@
-import { act, render } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import React from 'react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import MarkdownCode from '../../../../../../src/components/Content/MarkdownContent/MarkdownRenderer/MarkdownCode';
 
 const mockStore = configureStore([]);
+const hashDiagram = (diagram: string): string =>
+  Math.abs(
+    Array.from(diagram).reduce((hash, char) => {
+      const nextHash = (hash << 5) - hash + char.charCodeAt(0);
+      return nextHash & nextHash;
+    }, 0),
+  ).toString(36);
 
 describe('MarkdownCode', () => {
   let store: unknown;
@@ -46,5 +53,29 @@ describe('MarkdownCode', () => {
       ));
     });
     expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should render PlantUML renderer for puml code blocks', () => {
+    const chart = '@startuml\nA --> B\n@enduml';
+    const hash = hashDiagram(chart);
+    store = mockStore({
+      config: {
+        fontFamilyMonospace: 'monospace',
+        syntaxHighlighterTheme: 'github',
+      },
+      plantUML: {
+        svgCache: {},
+        loading: { [hash]: true },
+        errors: { [hash]: null },
+      },
+    });
+
+    render(
+      <Provider store={store}>
+        <MarkdownCode className="language-puml">{chart}</MarkdownCode>
+      </Provider>
+    );
+
+    expect(screen.getByText('Loading PlantUML diagram...')).toBeInTheDocument();
   });
 });

--- a/packages/frontend/test/unit/components/Content/MarkdownContent/MarkdownRenderer/MarkdownRenderer.test.tsx
+++ b/packages/frontend/test/unit/components/Content/MarkdownContent/MarkdownRenderer/MarkdownRenderer.test.tsx
@@ -26,18 +26,6 @@ jest.mock('../../../../../../src/components/Content/MarkdownContent/MarkdownRend
 jest.mock('react-markdown', () => {
   const React = jest.requireActual('react');
   const ActualReactMarkdown = jest.requireActual('react-markdown').default;
-
-  
-  const MockCode = (props: React.ComponentProps<'pre'>) => {
-    if (props.className && props.className.includes('language-mermaid')) {
-      return <div data-testid="mock-mermaid-chart">{props.children}</div>;
-    }
-    return (
-      <pre data-testid="mock-syntax-highlighter" className={props.className}>
-        <code data-testid="mock-syntax-highlighter-code">{props.children}</code>
-      </pre>
-    );
-  };
   const MockH1 = (props: React.ComponentProps<'h1'>) => <h1 data-testid="mock-h1" {...props}>{props.children}</h1>;
   const MockP = (props: React.ComponentProps<'p'>) => <p data-testid="mock-p" {...props}>{props.children}</p>;
 
@@ -51,11 +39,50 @@ jest.mock('react-markdown', () => {
     }) => {
       const finalComponents = {
         ...components,
-        
-        code: MockCode,
         h1: MockH1,
         p: MockP,
       };
+
+      if (children === '__CODE__' && finalComponents.code) {
+        return (
+          <div data-testid="mock-react-markdown-root">
+            {finalComponents.code({
+              inline: false,
+              className: 'language-javascript',
+              children: 'console.log("Hello");',
+            } as React.ComponentProps<'code'>)}
+          </div>
+        );
+      }
+
+      if (children === '__MERMAID__' && finalComponents.code) {
+        return (
+          <div data-testid="mock-react-markdown-root">
+            {finalComponents.code({
+              inline: false,
+              className: 'language-mermaid',
+              children: 'graph TD; A-->B;',
+            } as React.ComponentProps<'code'>)}
+          </div>
+        );
+      }
+
+      if (children === '__TABLE__' && finalComponents.table) {
+        return (
+          <div data-testid="mock-react-markdown-root">
+            {finalComponents.table({
+              children: (
+                <tbody>
+                  <tr>
+                    <td>mdts</td>
+                  </tr>
+                </tbody>
+              ),
+            } as React.ComponentProps<'table'>)}
+          </div>
+        );
+      }
+
       return (
         <div data-testid="mock-react-markdown-root">
           <ActualReactMarkdown components={finalComponents} remarkPlugins={remarkPlugins} rehypePlugins={rehypePlugins}>
@@ -69,27 +96,34 @@ jest.mock('react-markdown', () => {
 
 // Mock SyntaxHighlighter
 jest.mock('react-syntax-highlighter', () => ({
-  Prism: {
-    SyntaxHighlighter: ({
-      children,
-      language,
-      ...props
-    }: {
-      children: React.ReactNode;
-      language: string;
-      [key: string]: unknown;
-    }) => (
-      <pre data-testid="mock-syntax-highlighter" className={`language-${language}`} {...props}>
-        <code data-testid="mock-syntax-highlighter-code">{children}</code>
-      </pre>
-    ),
-  },
+  PrismAsyncLight: (props: {
+    children: React.ReactNode;
+    language: string;
+    className?: string;
+    customStyle?: unknown;
+    showLineNumbers?: boolean;
+    codeTagProps?: unknown;
+    PreTag?: unknown;
+    [key: string]: unknown;
+  }) => (
+    <pre
+      data-testid="mock-syntax-highlighter"
+      className={props.className}
+      data-language={props.language}
+    >
+      <code data-testid="mock-syntax-highlighter-code">{props.children}</code>
+    </pre>
+  ),
   nightOwl: {},
   prism: {},
 }));
 
 
-const renderWithProviders = (content: string, selectedFilePath: string | null = null) => {
+const renderWithProviders = (
+  content: string,
+  selectedFilePath: string | null = null,
+  enableBreaks = false
+) => {
   const theme = createTheme({
     palette: {
       mode: 'light',
@@ -122,7 +156,11 @@ const renderWithProviders = (content: string, selectedFilePath: string | null = 
     <Provider store={store}>
       <BrowserRouter>
         <ThemeProvider theme={theme}>
-          <MarkdownRenderer content={content} selectedFilePath={selectedFilePath} />
+          <MarkdownRenderer
+            content={content}
+            selectedFilePath={selectedFilePath}
+            enableBreaks={enableBreaks}
+          />
         </ThemeProvider>
       </BrowserRouter>
     </Provider>
@@ -146,15 +184,15 @@ describe('MarkdownRenderer', () => {
   });
 
   it('renders code blocks with syntax highlighting', () => {
-    const content = '```javascript\nconsole.log("Hello");\n```';
+    const content = '__CODE__';
     renderWithProviders(content);
     expect(screen.getByTestId('mock-syntax-highlighter')).toBeInTheDocument();
     expect(screen.getByTestId('mock-syntax-highlighter-code')).toHaveTextContent('console.log("Hello");');
-    expect(screen.getByTestId('mock-syntax-highlighter')).toHaveClass('language-javascript');
+    expect(screen.getByTestId('mock-syntax-highlighter')).toHaveAttribute('data-language', 'javascript');
   });
 
   it('renders mermaid diagrams for mermaid code blocks', () => {
-    const content = '```mermaid\ngraph TD; A-->B;\n```';
+    const content = '__MERMAID__';
     renderWithProviders(content);
     expect(screen.getByTestId('mock-mermaid-chart')).toBeInTheDocument();
     expect(screen.getByTestId('mock-mermaid-chart')).toHaveTextContent('graph TD; A-->B;');
@@ -203,5 +241,18 @@ describe('MarkdownRenderer', () => {
     renderWithProviders(content, '/path/to/current.md');
     const link = screen.getByTestId('markdown-link');
     expect(link).toHaveAttribute('href', '#section');
+  });
+
+  it('renders single line breaks as breaks when enabled', () => {
+    const { container } = renderWithProviders('First line\nSecond line', null, true);
+    expect(container.querySelector('br')).toBeInTheDocument();
+  });
+
+  it('wraps markdown tables in a table wrapper', () => {
+    const content = '__TABLE__';
+    const { container } = renderWithProviders(content);
+    expect(container.querySelector('.table-wrapper')).toBeInTheDocument();
+    expect(screen.getByRole('table')).toBeInTheDocument();
+    expect(screen.getByText('mdts')).toBeInTheDocument();
   });
 });

--- a/packages/frontend/test/unit/components/LeftPane/FileTree.mobile.test.tsx
+++ b/packages/frontend/test/unit/components/LeftPane/FileTree.mobile.test.tsx
@@ -1,0 +1,95 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { thunk } from 'redux-thunk';
+import FileTree from '../../../../src/components/LeftPane/FileTree';
+import useIsMobile from '../../../../src/hooks/useIsMobile';
+import { fetchFileTree, setExpandedNodes } from '../../../../src/store/slices/fileTreeSlice';
+
+const mockStore = configureStore([thunk]);
+
+jest.mock('../../../../src/store/slices/fileTreeSlice', () => ({
+  ...jest.requireActual('../../../../src/store/slices/fileTreeSlice'),
+  fetchFileTree: Object.assign(jest.fn(() => ({ type: 'fileTree/fetchFileTree/pending' })), {
+    fulfilled: jest.fn((payload) => ({ type: 'fileTree/fetchFileTree/fulfilled', payload })),
+  }),
+  setExpandedNodes: jest.fn((payload) => ({ type: 'fileTree/setExpandedNodes', payload })),
+}));
+
+jest.mock('../../../../src/hooks/useIsMobile', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('../../../../src/components/LeftPane/FileTreeContent/FileTreeContent', () => {
+  const React = jest.requireActual('react');
+
+  return {
+    __esModule: true,
+    default: ({ onExpandedItemsChange, onFileSelect }) => {
+      const handleExpandItems = () => onExpandedItemsChange({}, ['folder1']);
+      const handleSelectFile = () => onFileSelect('/docs/readme.md');
+
+      return React.createElement(
+        'div',
+        null,
+        React.createElement('button', { onClick: handleExpandItems }, 'expand items'),
+        React.createElement('button', { onClick: handleSelectFile }, 'select file')
+      );
+    },
+  };
+});
+
+describe('FileTree mobile behavior', () => {
+  let store;
+
+  const renderFileTree = (props = {}) => render(
+    <Provider store={store}>
+      <FileTree
+        onFileSelect={jest.fn()}
+        isOpen={true}
+        onToggle={jest.fn()}
+        selectedFilePath={null}
+        {...props}
+      />
+    </Provider>
+  );
+
+  beforeEach(() => {
+    (useIsMobile as jest.Mock).mockReturnValue(true);
+    store = mockStore({
+      fileTree: {
+        fileTree: [{ 'folder1': [{ path: 'folder1/file1.md', status: ' ' }] }],
+        filteredFileTree: [{ 'folder1': [{ path: 'folder1/file1.md', status: ' ' }] }],
+        loading: false,
+        error: null,
+        searchQuery: '',
+        expandedNodes: [],
+        mountedDirectoryPath: '',
+      },
+    });
+    store.dispatch = jest.fn();
+  });
+
+  test('dispatches expanded items updates from the mobile tree content', () => {
+    renderFileTree();
+
+    fireEvent.click(screen.getByRole('button', { name: 'expand items' }));
+
+    expect(store.dispatch).toHaveBeenCalledWith(fetchFileTree());
+    expect(store.dispatch).toHaveBeenCalledWith(setExpandedNodes(['folder1']));
+  });
+
+  test('closes the mobile drawer after selecting a file', () => {
+    const onFileSelect = jest.fn();
+    const onToggle = jest.fn();
+
+    renderFileTree({ onFileSelect, onToggle });
+
+    fireEvent.click(screen.getByRole('button', { name: 'select file' }));
+
+    expect(onFileSelect).toHaveBeenCalledWith('/docs/readme.md');
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/frontend/test/unit/components/LeftPane/FileTreeContent/FileTreeContent.test.tsx
+++ b/packages/frontend/test/unit/components/LeftPane/FileTreeContent/FileTreeContent.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, fireEvent } from '@testing-library/react';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
 import React from 'react';
 import FileTreeContent from '../../../../../src/components/LeftPane/FileTreeContent/FileTreeContent';
 
@@ -16,6 +17,25 @@ describe('FileTreeContent', () => {
     { 'folder1': [{ path: 'file1.md', status: ' ' }, { 'subfolder': [{ path: 'folder1/subfolder/file2.txt', status: ' ' }] }] },
     { path: 'file3.js', status: ' ' },
   ];
+  const statusFileTree = [
+    { path: 'modified.md', status: 'M' },
+    { path: 'untracked.md', status: '?' },
+    { path: 'added.md', status: 'A' },
+    { path: 'deleted.md', status: 'D' },
+    { path: 'renamed.md', status: 'R' },
+    { path: 'copied.md', status: 'C' },
+    { path: 'unknown.md', status: 'X' },
+  ];
+  const theme = createTheme({
+    palette: {
+      info: { main: 'rgb(1, 2, 3)' },
+      success: { main: 'rgb(4, 5, 6)' },
+      error: { main: 'rgb(7, 8, 9)' },
+      warning: { main: 'rgb(10, 11, 12)' },
+      secondary: { main: 'rgb(13, 14, 15)' },
+      text: { primary: 'rgb(16, 17, 18)' },
+    },
+  });
 
   test('renders loading spinner when loading is true', () => {
     render(
@@ -59,6 +79,48 @@ describe('FileTreeContent', () => {
     expect(asFragment()).toMatchSnapshot();
     expect(screen.getByText('folder1')).toBeInTheDocument();
     expect(screen.getByText('file3.js')).toBeInTheDocument();
+  });
+
+  test('renders existing tree while loading when filtered tree already has content', () => {
+    render(
+      <FileTreeContent
+        filteredFileTree={mockFileTree}
+        loading={true}
+        error={null}
+        expandedNodes={['folder1']}
+        onFileSelect={jest.fn()}
+        onExpandedItemsChange={jest.fn()}
+      />
+    );
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+    expect(screen.getByText('folder1')).toBeInTheDocument();
+  });
+
+  test('applies theme colors for each git status', () => {
+    render(
+      <ThemeProvider theme={theme}>
+        <FileTreeContent
+          filteredFileTree={statusFileTree}
+          loading={false}
+          error={null}
+          expandedNodes={[]}
+          onFileSelect={jest.fn()}
+          onExpandedItemsChange={jest.fn()}
+        />
+      </ThemeProvider>
+    );
+
+    [
+      ['modified.md', 'rgb(1, 2, 3)'],
+      ['untracked.md', 'rgb(4, 5, 6)'],
+      ['added.md', 'rgb(4, 5, 6)'],
+      ['deleted.md', 'rgb(7, 8, 9)'],
+      ['renamed.md', 'rgb(10, 11, 12)'],
+      ['copied.md', 'rgb(13, 14, 15)'],
+      ['unknown.md', 'rgb(16, 17, 18)'],
+    ].forEach(([fileName, color]) => {
+      expect(screen.getByText(fileName)).toHaveStyle({ color });
+    });
   });
 
   test('calls onFileSelect when a file is clicked', () => {

--- a/packages/frontend/test/unit/components/RightPane/Outline.test.tsx
+++ b/packages/frontend/test/unit/components/RightPane/Outline.test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import { thunk } from 'redux-thunk';
+import useIsMobile from '../../../../src/hooks/useIsMobile';
 import Outline from '../../../../src/components/RightPane/Outline';
 import { fetchOutline } from '../../../../src/store/slices/outlineSlice';
 
@@ -13,10 +14,22 @@ jest.mock('../../../../src/store/slices/outlineSlice', () => ({
   fetchOutline: jest.fn(() => ({ type: 'outline/fetchOutline/pending' })),
 }));
 
+jest.mock('../../../../src/hooks/useIsMobile', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
 describe('Outline', () => {
   let store;
 
+  const renderOutline = (props = {}) => render(
+    <Provider store={store}>
+      <Outline filePath="/test.md" onItemClick={jest.fn()} isOpen={true} onToggle={jest.fn()} {...props} />
+    </Provider>
+  );
+
   beforeEach(() => {
+    (useIsMobile as jest.Mock).mockReturnValue(false);
     store = mockStore({
       outline: {
         outline: [{ id: 'title', content: 'Title', level: 1 }],
@@ -41,30 +54,18 @@ describe('Outline', () => {
   });
 
   test('dispatches fetchOutline on mount with correct filePath', () => {
-    render(
-      <Provider store={store}>
-        <Outline filePath="/test.md" onItemClick={jest.fn()} isOpen={true} onToggle={jest.fn()} />
-      </Provider>
-    );
+    renderOutline();
     expect(store.dispatch).toHaveBeenCalledWith(fetchOutline('/test.md'));
   });
 
   test('dispatches fetchOutline with null when filePath is null', () => {
-    render(
-      <Provider store={store}>
-        <Outline filePath={null} onItemClick={jest.fn()} isOpen={true} onToggle={jest.fn()} />
-      </Provider>
-    );
+    renderOutline({ filePath: null });
     expect(store.dispatch).toHaveBeenCalledWith(fetchOutline(null));
   });
 
   test('calls onItemClick when an outline item is clicked', () => {
     const onItemClickMock = jest.fn();
-    render(
-      <Provider store={store}>
-        <Outline filePath="/test.md" onItemClick={onItemClickMock} isOpen={true} onToggle={jest.fn()} />
-      </Provider>
-    );
+    renderOutline({ onItemClick: onItemClickMock });
 
     fireEvent.click(screen.getByText('Title'));
     expect(onItemClickMock).toHaveBeenCalledWith('title');
@@ -79,11 +80,7 @@ describe('Outline', () => {
       },
     });
 
-    render(
-      <Provider store={store}>
-        <Outline filePath="/test.md" onItemClick={jest.fn()} isOpen={true} onToggle={jest.fn()} />
-      </Provider>
-    );
+    renderOutline();
 
     expect(screen.getByRole('progressbar')).toBeInTheDocument();
   });
@@ -97,12 +94,30 @@ describe('Outline', () => {
       },
     });
 
-    render(
-      <Provider store={store}>
-        <Outline filePath="/test.md" onItemClick={jest.fn()} isOpen={true} onToggle={jest.fn()} />
-      </Provider>
-    );
+    renderOutline();
 
     expect(screen.getByText('Error: Failed to load outline')).toBeInTheDocument();
+  });
+
+  test('closes the mobile outline after selecting an item', () => {
+    const onItemClickMock = jest.fn();
+    const onToggleMock = jest.fn();
+    (useIsMobile as jest.Mock).mockReturnValue(true);
+
+    renderOutline({ onItemClick: onItemClickMock, onToggle: onToggleMock });
+
+    fireEvent.click(screen.getByText('Title'));
+
+    expect(onItemClickMock).toHaveBeenCalledWith('title');
+    expect(onToggleMock).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('Outline')).toBeInTheDocument();
+  });
+
+  test('hides outline content when collapsed on desktop', () => {
+    renderOutline({ isOpen: false });
+
+    expect(screen.queryByText('Title')).not.toBeInTheDocument();
+    expect(screen.queryByText('Outline')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('toggle outline')).toBeInTheDocument();
   });
 });

--- a/packages/frontend/test/unit/components/SettingsDialog/ColorSchemeSettingsTab.test.tsx
+++ b/packages/frontend/test/unit/components/SettingsDialog/ColorSchemeSettingsTab.test.tsx
@@ -1,10 +1,58 @@
-import { render } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import React from 'react';
 import ColorSchemeSettingsTab from '../../../../src/components/SettingsDialog/ColorSchemeSettingsTab';
 
+const createProps = () => ({
+  darkMode: 'dark' as const,
+  theme: 'default',
+  syntaxHighlighterTheme: 'auto',
+  handleToggleDarkMode: jest.fn(),
+  setSyntaxHighlighterTheme: jest.fn(),
+  handleToggleTheme: jest.fn(),
+});
+
+const renderComponent = (props = createProps()) => render(<ColorSchemeSettingsTab {...props} />);
+
 describe('ColorSchemeSettingsTab', () => {
   it('should render correctly', () => {
-    const { asFragment } = render(<ColorSchemeSettingsTab />);
+    const { asFragment } = renderComponent();
     expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('calls handleToggleDarkMode only when another mode is selected', () => {
+    const props = createProps();
+
+    renderComponent(props);
+
+    fireEvent.click(screen.getByRole('button', { name: 'light' }));
+    fireEvent.click(screen.getByRole('button', { name: 'dark' }));
+
+    expect(props.handleToggleDarkMode).toHaveBeenCalledTimes(1);
+    expect(props.handleToggleDarkMode).toHaveBeenCalledWith('light');
+  });
+
+  it('calls handleToggleTheme when selecting another theme', async () => {
+    const props = createProps();
+
+    renderComponent(props);
+
+    fireEvent.mouseDown(screen.getAllByRole('combobox')[0]);
+    await waitFor(() => screen.getByRole('option', { name: 'Aurora' }));
+    fireEvent.click(screen.getByRole('option', { name: 'Aurora' }));
+
+    expect(props.handleToggleTheme).toHaveBeenCalledWith('aurora');
+  });
+
+  it('calls setSyntaxHighlighterTheme when selecting another syntax theme', async () => {
+    const props = createProps();
+
+    renderComponent(props);
+
+    const select = screen.getByTestId('syntax-highlighter-theme-select');
+    fireEvent.mouseDown(within(select).getByRole('combobox'));
+    await waitFor(() => screen.getByRole('option', { name: 'Atom Dark' }));
+    fireEvent.click(screen.getByRole('option', { name: 'Atom Dark' }));
+
+    expect(props.setSyntaxHighlighterTheme).toHaveBeenCalledWith('atomDark');
   });
 });

--- a/packages/frontend/test/unit/components/SettingsDialog/LayoutSettingsTab.test.tsx
+++ b/packages/frontend/test/unit/components/SettingsDialog/LayoutSettingsTab.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import LayoutSettingsTab from '../../../../src/components/SettingsDialog/LayoutSettingsTab';
 
@@ -13,5 +13,56 @@ describe('LayoutSettingsTab', () => {
       />
     );
     expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('calls handleToggleContentMode when selecting another mode', () => {
+    const handleToggleContentMode = jest.fn();
+
+    render(
+      <LayoutSettingsTab
+        contentMode="compact"
+        enableBreaks={false}
+        handleToggleContentMode={handleToggleContentMode}
+        setEnableBreaks={jest.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'full' }));
+
+    expect(handleToggleContentMode).toHaveBeenCalledWith('full');
+  });
+
+  it('does not call handleToggleContentMode when the selected mode is clicked again', () => {
+    const handleToggleContentMode = jest.fn();
+
+    render(
+      <LayoutSettingsTab
+        contentMode="compact"
+        enableBreaks={false}
+        handleToggleContentMode={handleToggleContentMode}
+        setEnableBreaks={jest.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'compact' }));
+
+    expect(handleToggleContentMode).not.toHaveBeenCalled();
+  });
+
+  it('calls setEnableBreaks with the next checked state', () => {
+    const setEnableBreaks = jest.fn();
+
+    render(
+      <LayoutSettingsTab
+        contentMode="compact"
+        enableBreaks={false}
+        handleToggleContentMode={jest.fn()}
+        setEnableBreaks={setEnableBreaks}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('switch', { name: 'Enable soft line breaks' }));
+
+    expect(setEnableBreaks).toHaveBeenCalledWith(true);
   });
 });

--- a/packages/frontend/test/unit/components/SettingsDialog/__snapshots__/ColorSchemeSettingsTab.test.tsx.snap
+++ b/packages/frontend/test/unit/components/SettingsDialog/__snapshots__/ColorSchemeSettingsTab.test.tsx.snap
@@ -17,8 +17,8 @@ exports[`ColorSchemeSettingsTab should render correctly 1`] = `
     >
       <button
         aria-label="dark"
-        aria-pressed="false"
-        class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButton-root MuiToggleButton-fullWidth MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-firstButton css-zhjb61-MuiButtonBase-root-MuiToggleButton-root"
+        aria-pressed="true"
+        class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButton-root Mui-selected MuiToggleButton-fullWidth MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-firstButton css-zhjb61-MuiButtonBase-root-MuiToggleButton-root"
         tabindex="0"
         type="button"
         value="dark"
@@ -61,12 +61,22 @@ exports[`ColorSchemeSettingsTab should render correctly 1`] = `
         role="combobox"
         tabindex="0"
       >
-        <span
-          aria-hidden="true"
-          class="notranslate"
+        <div
+          class="MuiBox-root css-7pf6at"
         >
-          ​
-        </span>
+          <div
+            class="MuiBox-root css-157xh8y"
+          >
+            <div
+              class="MuiBox-root css-dergdt"
+            />
+          </div>
+          <p
+            class="MuiTypography-root MuiTypography-body2 css-2wbpcv-MuiTypography-root"
+          >
+            Default
+          </p>
+        </div>
       </div>
       <input
         aria-hidden="true"
@@ -74,6 +84,7 @@ exports[`ColorSchemeSettingsTab should render correctly 1`] = `
         class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
         id="_r_1_"
         tabindex="-1"
+        value="default"
       />
       <svg
         aria-hidden="true"

--- a/packages/frontend/test/unit/hooks/useSettingsForm.test.tsx
+++ b/packages/frontend/test/unit/hooks/useSettingsForm.test.tsx
@@ -1,0 +1,38 @@
+import { act, renderHook } from '@testing-library/react';
+import React from 'react';
+import { Provider } from 'react-redux';
+import { WEB_SAFE_FONTS, WEB_SAFE_MONOSPACE_FONTS } from '../../../src/constants';
+import { useSettingsForm } from '../../../src/hooks/useSettingsForm';
+import { createMockStore } from '../../utils';
+
+describe('useSettingsForm', () => {
+  const renderUseSettingsForm = () => {
+    const store = createMockStore({
+      config: {
+        theme: 'default',
+        fontFamily: 'Custom Sans',
+        fontFamilyMonospace: 'Custom Mono',
+      },
+    });
+
+    return renderHook(() => useSettingsForm(), {
+      wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
+    });
+  };
+
+  test('updates the theme and resets custom fonts when select mode is chosen', () => {
+    const { result } = renderUseSettingsForm();
+
+    act(() => {
+      result.current.handleToggleTheme('aurora');
+      result.current.handleFontInputModeChange({} as React.MouseEvent<HTMLElement>, 'select');
+      result.current.handleFontInputModeMonospaceChange({} as React.MouseEvent<HTMLElement>, 'select');
+    });
+
+    expect(result.current.themeType).toBe('aurora');
+    expect(result.current.fontInputMode).toBe('select');
+    expect(result.current.fontFamily).toBe(WEB_SAFE_FONTS[0]);
+    expect(result.current.fontInputModeMonospace).toBe('select');
+    expect(result.current.fontFamilyMonospace).toBe(WEB_SAFE_MONOSPACE_FONTS[0]);
+  });
+});

--- a/packages/frontend/test/unit/hooks/useSyntaxHighlighterTheme.test.tsx
+++ b/packages/frontend/test/unit/hooks/useSyntaxHighlighterTheme.test.tsx
@@ -1,0 +1,49 @@
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import { renderHook } from '@testing-library/react';
+import React from 'react';
+import { atomDark, coy, vs } from 'react-syntax-highlighter/dist/esm/styles/prism';
+import { useSyntaxHighlighterTheme } from '../../../src/hooks/useSyntaxHighlighterTheme';
+
+const createWrapper = (mode: 'light' | 'dark') => {
+  const theme = createTheme({ palette: { mode } });
+
+  function ThemeWrapper({ children }: { children: React.ReactNode }) {
+    return <ThemeProvider theme={theme}>{children}</ThemeProvider>;
+  }
+
+  return ThemeWrapper;
+};
+
+describe('useSyntaxHighlighterTheme', () => {
+  test('returns atomDark when auto mode uses a dark palette', () => {
+    const { result } = renderHook(() => useSyntaxHighlighterTheme('auto'), {
+      wrapper: createWrapper('dark'),
+    });
+
+    expect(result.current).toBe(atomDark);
+  });
+
+  test('returns vs when auto mode uses a light palette', () => {
+    const { result } = renderHook(() => useSyntaxHighlighterTheme('auto'), {
+      wrapper: createWrapper('light'),
+    });
+
+    expect(result.current).toBe(vs);
+  });
+
+  test('returns the selected theme when the name is known', () => {
+    const { result } = renderHook(() => useSyntaxHighlighterTheme('coy'), {
+      wrapper: createWrapper('light'),
+    });
+
+    expect(result.current).toBe(coy);
+  });
+
+  test('falls back to atomDark when the theme name is unknown', () => {
+    const { result } = renderHook(() => useSyntaxHighlighterTheme('unknown-theme'), {
+      wrapper: createWrapper('light'),
+    });
+
+    expect(result.current).toBe(atomDark);
+  });
+});

--- a/packages/frontend/test/unit/hooks/useTheme.test.tsx
+++ b/packages/frontend/test/unit/hooks/useTheme.test.tsx
@@ -5,6 +5,17 @@ import { useTheme } from '../../../src/hooks/useTheme';
 import { createMockStore } from '../../utils';
 
 describe('useTheme', () => {
+  const mockMatchMedia = (matches: boolean) => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn().mockReturnValue({
+        matches,
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+      }),
+    });
+  };
+
   test('should return a light theme when darkMode is false', () => {
     const store = createMockStore({ appSetting: { darkMode: 'light' } });
     const { result } = renderHook(() => useTheme(), {
@@ -37,5 +48,33 @@ describe('useTheme', () => {
       wrapper: ({ children }) => <Provider store={darkStore}>{children}</Provider>,
     });
     expect(darkThemeResult.current.palette.primary.main).toBe('#1976d2');
+  });
+
+  test('should use the system dark preference when darkMode is auto', () => {
+    mockMatchMedia(true);
+    const store = createMockStore({
+      appSetting: { darkMode: 'auto' },
+      config: { theme: 'aurora' },
+    });
+    const { result } = renderHook(() => useTheme(), {
+      wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
+    });
+    expect(result.current.palette.mode).toBe('dark');
+    expect(result.current.palette.background.default).toBe('#00251a');
+    expect(result.current.palette.background.paper).toBe('#012a4a');
+  });
+
+  test('should fall back to the default light theme for an unknown theme id', () => {
+    mockMatchMedia(false);
+    const store = createMockStore({
+      appSetting: { darkMode: 'auto' },
+      config: { theme: 'unknown-theme' },
+    });
+    const { result } = renderHook(() => useTheme(), {
+      wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
+    });
+    expect(result.current.palette.mode).toBe('light');
+    expect(result.current.palette.background.default).toBe('#f5f7fa');
+    expect(result.current.palette.background.paper).toBe('#eef1f5');
   });
 });

--- a/packages/frontend/test/unit/hooks/useWebSocket.test.tsx
+++ b/packages/frontend/test/unit/hooks/useWebSocket.test.tsx
@@ -46,6 +46,7 @@ describe('useWebSocket', () => {
     mockWebSocket.close.mockClear();
     mockWebSocket.onmessage = jest.fn(); // Reset onmessage for each test
     mockWebSocket.onopen = jest.fn(); // Reset onopen for each test
+    mockWebSocket.onclose = jest.fn(); // Reset onclose for each test
     mockWebSocket.onerror = jest.fn(); // Reset onerror for each test
   });
 
@@ -127,6 +128,14 @@ describe('useWebSocket', () => {
     mockWebSocket.onerror(errorEvent);
     expect(consoleErrorSpy).toHaveBeenCalledWith('WebSocket error:', errorEvent);
     consoleErrorSpy.mockRestore();
+  });
+
+  test('should log when WebSocket closes', () => {
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    render(<TestComponent currentPath="/test.md" />);
+    mockWebSocket.onclose();
+    expect(consoleLogSpy).toHaveBeenCalledWith('WebSocket disconnected');
+    consoleLogSpy.mockRestore();
   });
 
   test('should send watch-file message when currentPath changes', () => {

--- a/packages/frontend/test/unit/index.test.tsx
+++ b/packages/frontend/test/unit/index.test.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+
+type AppSetting = {
+  darkMode: 'auto' | 'dark' | 'light';
+  contentMode: 'compact' | 'full';
+  fileTreeOpen: boolean;
+  outlineOpen: boolean;
+};
+
+type MockStore = {
+  getState: jest.Mock;
+  subscribe: jest.Mock;
+};
+
+const createStore = (appSetting: AppSetting) => {
+  let listener: (() => void) | undefined;
+  const store: MockStore = {
+    getState: jest.fn(() => ({ appSetting })),
+    subscribe: jest.fn((callback: () => void) => {
+      listener = callback;
+      return jest.fn();
+    }),
+  };
+
+  return { store, trigger: () => listener?.() };
+};
+
+const loadEntryPoint = async (store: MockStore) => {
+  const render = jest.fn();
+  const createRoot = jest.fn(() => ({ render }));
+
+  jest.resetModules();
+  document.body.innerHTML = '<div id="root"></div>';
+
+  jest.doMock('react-dom/client', () => ({
+    __esModule: true,
+    default: { createRoot },
+    createRoot,
+  }));
+  jest.doMock('react-redux', () => ({
+    __esModule: true,
+    Provider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  }));
+  jest.doMock('react-router-dom', () => ({
+    __esModule: true,
+    BrowserRouter: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  }));
+  jest.doMock('../../src/App', () => ({
+    __esModule: true,
+    default: () => <div>App</div>,
+  }));
+  jest.doMock('../../src/store/store', () => ({
+    __esModule: true,
+    store,
+  }));
+
+  await jest.isolateModulesAsync(async () => {
+    await import('../../src/index');
+  });
+
+  return { createRoot, render };
+};
+
+describe('index', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    localStorage.clear();
+    document.body.innerHTML = '';
+  });
+
+  it('renders the app and persists app settings on store updates', async () => {
+    const appSetting = {
+      darkMode: 'dark',
+      contentMode: 'full',
+      fileTreeOpen: false,
+      outlineOpen: true,
+    } as const;
+    const setItemSpy = jest.spyOn(Storage.prototype, 'setItem');
+    const { store, trigger } = createStore(appSetting);
+    const { createRoot, render } = await loadEntryPoint(store);
+
+    expect(createRoot).toHaveBeenCalledWith(document.getElementById('root'));
+    expect(render).toHaveBeenCalledTimes(1);
+    expect(store.subscribe).toHaveBeenCalledWith(expect.any(Function));
+
+    trigger();
+
+    expect(setItemSpy).toHaveBeenCalledWith('appSetting', JSON.stringify(appSetting));
+  });
+
+  it('logs an error when app settings cannot be persisted', async () => {
+    const error = new Error('save failed');
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw error;
+    });
+    const { store, trigger } = createStore({
+      darkMode: 'light',
+      contentMode: 'compact',
+      fileTreeOpen: true,
+      outlineOpen: false,
+    });
+
+    await loadEntryPoint(store);
+    trigger();
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Could not save state to localStorage', error);
+  });
+});

--- a/packages/frontend/test/unit/store/configSlice.test.ts
+++ b/packages/frontend/test/unit/store/configSlice.test.ts
@@ -80,4 +80,34 @@ describe('configSlice', () => {
     expect(store.getState().config.fontFamily).toEqual('TestFontAfterSave');
     expect(store.getState().config.fontSize).toEqual(18);
   });
+
+  it('should log and reject when saving config to backend fails', async () => {
+    const error = new Error('network error');
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    (global.fetch as jest.MockedFunction<typeof fetch>).mockRejectedValueOnce(error);
+
+    const action = await store.dispatch(
+      saveConfigToBackend({
+        fontFamily: 'SavedFont',
+        fontFamilyMonospace: 'SavedMono',
+        fontSize: 18,
+        theme: 'default',
+        syntaxHighlighterTheme: 'auto',
+        enableBreaks: false,
+      }),
+    );
+
+    expect(action.type).toEqual('config/saveConfigToBackend/rejected');
+    expect(action.error.message).toEqual('network error');
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to save settings:', error);
+    expect(api.fetchData).not.toHaveBeenCalled();
+    expect(store.getState().config).toEqual({
+      fontFamily: 'Roboto',
+      fontFamilyMonospace: 'monospace',
+      fontSize: 14,
+      theme: 'default',
+      syntaxHighlighterTheme: 'auto',
+      enableBreaks: false,
+    });
+  });
 });

--- a/packages/frontend/test/unit/store/fileTreeSlice.test.ts
+++ b/packages/frontend/test/unit/store/fileTreeSlice.test.ts
@@ -147,6 +147,19 @@ describe('fileTreeSlice', () => {
     expect(store.getState().fileTree.mountedDirectoryPath).toEqual('/new/path');
   });
 
+  it('should remove the oldest expanded node cache when recent paths exceed the limit', () => {
+    const paths = Array.from({ length: 11 }, (_, index) => `/test/path-${index + 1}`);
+
+    paths.forEach((path, index) => {
+      store.dispatch(setMountedDirectoryPath(path));
+      store.dispatch(setExpandedNodes([`node-${index + 1}`]));
+    });
+
+    expect(localStorage.getItem('mdts_expanded_nodes_/test/path-1')).toBeNull();
+    expect(localStorage.getItem('mdts_expanded_nodes_/test/path-11')).toEqual(JSON.stringify(['node-11']));
+    expect(localStorage.getItem('mdts_recent_paths')).toEqual(JSON.stringify(paths.slice(1).reverse()));
+  });
+
   describe('fetchFileTree async thunk', () => {
     it('should handle pending state', () => {
       store.dispatch(fetchFileTree.pending('requestId', undefined));

--- a/packages/frontend/test/unit/store/plantUMLSlice.test.ts
+++ b/packages/frontend/test/unit/store/plantUMLSlice.test.ts
@@ -7,6 +7,15 @@ import plantUMLReducer, {
 
 global.fetch = jest.fn();
 
+const hashDiagram = (diagram: string): string => {
+  return Math.abs(
+    Array.from(diagram).reduce((hash, char) => {
+      const nextHash = (hash << 5) - hash + char.charCodeAt(0);
+      return nextHash & nextHash;
+    }, 0),
+  ).toString(36);
+};
+
 const createTestStore = (initialState = {}) => {
   return configureStore({
     reducer: {
@@ -57,15 +66,7 @@ describe('plantUMLSlice', () => {
     it('should return cached SVG if available', async () => {
       const diagram = '@startuml\nA --> B\n@enduml';
       const cachedSvg = '<svg>cached</svg>';
-      
-      // Calculate the actual hash for the diagram
-      let hash = 0;
-      for (let i = 0; i < diagram.length; i++) {
-        const char = diagram.charCodeAt(i);
-        hash = ((hash << 5) - hash) + char;
-        hash = hash & hash;
-      }
-      const expectedHash = Math.abs(hash).toString(36);
+      const expectedHash = hashDiagram(diagram);
       
       const store = createTestStore({
         svgCache: { [expectedHash]: cachedSvg },
@@ -78,6 +79,37 @@ describe('plantUMLSlice', () => {
         hash: expectedHash,
         svg: cachedSvg,
       });
+    });
+
+    it('should fetch SVG successfully and cache it', async () => {
+      const diagram = '@startuml\nA --> B\n@enduml';
+      const svg = '<svg>generated</svg>';
+      const expectedHash = hashDiagram(diagram);
+
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        text: jest.fn().mockResolvedValue(svg),
+      });
+
+      const store = createTestStore();
+      const result = await store.dispatch(generatePlantUMLSvg(diagram));
+      const state = store.getState().plantUML;
+
+      expect(global.fetch).toHaveBeenCalledWith('/api/plantuml/svg', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ diagram }),
+      });
+      expect(result.type).toBe('plantUML/generateSvg/fulfilled');
+      expect(result.payload).toEqual({
+        hash: expectedHash,
+        svg,
+      });
+      expect(state.svgCache[expectedHash]).toBe(svg);
+      expect(state.loading[expectedHash]).toBe(false);
+      expect(state.errors[expectedHash]).toBe(null);
     });
 
     it('should handle fetch failure', async () => {

--- a/packages/frontend/test/unit/store/store.test.ts
+++ b/packages/frontend/test/unit/store/store.test.ts
@@ -1,0 +1,106 @@
+import { saveAppSetting } from '../../../src/store/slices/appSettingSlice';
+
+type StoreModule = typeof import('../../../src/store/store');
+type MatchMediaMock = MediaQueryList & { dispatchChange: (matches: boolean) => void };
+
+const defaultAppSetting = {
+  darkMode: 'auto',
+  contentMode: 'compact',
+  fileTreeOpen: true,
+  outlineOpen: true,
+} as const;
+
+const importStoreModule = async (): Promise<StoreModule> => {
+  jest.resetModules();
+  return import('../../../src/store/store');
+};
+
+const createMatchMedia = (initialMatches: boolean): MatchMediaMock => {
+  const listeners = new Set<(event: MediaQueryListEvent) => void>();
+  const mediaQueryList = {
+    matches: initialMatches,
+    media: '(prefers-color-scheme: dark)',
+    onchange: null,
+    addEventListener: jest.fn((event: string, listener: EventListenerOrEventListenerObject) => {
+      if (event === 'change' && typeof listener === 'function') listeners.add(listener);
+    }),
+    removeEventListener: jest.fn((event: string, listener: EventListenerOrEventListenerObject) => {
+      if (event === 'change' && typeof listener === 'function') listeners.delete(listener);
+    }),
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+    dispatchChange: (matches: boolean) => {
+      mediaQueryList.matches = matches;
+      [...listeners].map((listener) => listener({ matches } as MediaQueryListEvent));
+    },
+  };
+
+  return mediaQueryList as MatchMediaMock;
+};
+
+describe('store', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    localStorage.clear();
+    document.body.removeAttribute('data-theme');
+  });
+
+  it('uses the default app setting when localStorage is empty', async () => {
+    const { store } = await importStoreModule();
+
+    expect(store.getState().appSetting).toEqual(defaultAppSetting);
+  });
+
+  it('loads persisted app settings from localStorage', async () => {
+    localStorage.setItem('appSetting', JSON.stringify({
+      darkMode: 'light',
+      contentMode: 'full',
+      fileTreeOpen: false,
+      outlineOpen: false,
+    }));
+
+    const { store } = await importStoreModule();
+
+    expect(store.getState().appSetting).toEqual({
+      darkMode: 'light',
+      contentMode: 'full',
+      fileTreeOpen: false,
+      outlineOpen: false,
+    });
+  });
+
+  it('falls back to the default app setting when localStorage read fails', async () => {
+    const error = new Error('localStorage read failed');
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw error;
+    });
+
+    const { store } = await importStoreModule();
+
+    expect(store.getState().appSetting).toEqual(defaultAppSetting);
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Could not load state from localStorage', error);
+  });
+
+  it('applies explicit and auto themes when app settings change', async () => {
+    const matchMedia = createMatchMedia(false);
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn().mockReturnValue(matchMedia),
+    });
+
+    const { store } = await importStoreModule();
+
+    store.dispatch(saveAppSetting({ darkMode: 'dark', contentMode: 'compact' }));
+    expect(document.body).toHaveAttribute('data-theme', 'dark');
+
+    store.dispatch(saveAppSetting({ darkMode: 'auto', contentMode: 'compact' }));
+    expect(window.matchMedia).toHaveBeenCalledWith('(prefers-color-scheme: dark)');
+    expect(document.body).toHaveAttribute('data-theme', 'light');
+
+    matchMedia.dispatchChange(true);
+    expect(document.body).toHaveAttribute('data-theme', 'dark');
+    expect(matchMedia.addEventListener).toHaveBeenCalledWith('change', expect.any(Function));
+  });
+});

--- a/test/e2e/cli.test.ts
+++ b/test/e2e/cli.test.ts
@@ -1,8 +1,6 @@
 import axios from 'axios';
 import { ChildProcess, spawn } from 'child_process';
 import path from 'path';
-import fs from 'fs';
-import os from 'os';
 
 const cliPath = path.resolve(__dirname, '../../bin/mdts');
 const testDirectory = path.resolve(__dirname, '../fixtures/mountDirectory');
@@ -10,32 +8,14 @@ const port = 8522;
 
 describe('CLI e2e tests', () => {
   let cliProcess: ChildProcess;
-  let tempDir: string;
-  let originalPath: string | undefined;
 
   beforeAll(async () => {
-    // Create a temporary directory for our dummy 'open' executable
-    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mdts-test-'));
+    cliProcess = spawn('node', [cliPath, '-p', String(port), '--no-open', testDirectory]);
 
-    // Create a dummy 'open' executable that does nothing
-    const dummyOpenPath = path.join(tempDir, 'open');
-    fs.writeFileSync(dummyOpenPath, '#!/bin/bash\nexit 0');
-    fs.chmodSync(dummyOpenPath, '755'); // Make it executable
-
-    // Store original PATH and prepend our temp directory to it
-    originalPath = process.env.PATH;
-    process.env.PATH = `${tempDir}${path.delimiter}${process.env.PATH}`;
-
-    cliProcess = spawn('node', [cliPath, '-p', String(port), testDirectory], {
-      env: { ...process.env, PATH: process.env.PATH }, // Pass the modified PATH to the child process
-    });
-
-    // Optional: Log stderr for debugging
     cliProcess.stderr?.on('data', (data: Buffer) => {
       console.error(`CLI stderr: ${data}`);
     });
 
-    // Poll for server readiness
     const maxAttempts = 30;
     const delayMs = 1000;
     for (let i = 0; i < maxAttempts; i++) {
@@ -43,7 +23,7 @@ describe('CLI e2e tests', () => {
         const response = await axios.get(`http://localhost:${port}/api/markdown/content/test.md`);
         if (response.status === 200) {
           console.log(`Server is ready after ${i + 1} attempts.`);
-          return; // Server is ready
+          return;
         }
       } catch {
         // Server not ready yet, continue polling
@@ -51,18 +31,11 @@ describe('CLI e2e tests', () => {
       await new Promise(resolve => setTimeout(resolve, delayMs));
     }
     throw new Error('Server did not become ready within the timeout.');
-  }, 60000); // Keep the overall timeout for beforeAll
+  }, 60000);
 
   afterAll(() => {
     if (cliProcess) {
       cliProcess.kill();
-    }
-    // Clean up the temporary directory and restore original PATH
-    if (tempDir) {
-      fs.rmSync(tempDir, { recursive: true, force: true });
-    }
-    if (originalPath !== undefined) {
-      process.env.PATH = originalPath;
     }
   });
 

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -219,4 +219,11 @@ describe('cli', () => {
         expect(mockServe).toHaveBeenCalledWith({ directory: path.resolve('.') }, 8521, 'localhost', false);
       });
   });
+
+  it('should resolve open module in requireOpen', async () => {
+    const anotherCli = new CLI();
+    const openModule = await import('open');
+
+    await expect(anotherCli.requireOpen()).resolves.toBe(openModule.default);
+  });
 });

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -2,6 +2,7 @@ import { CLI } from '../../src/cli';
 import path from 'path';
 import { serve } from '../../src/server/server';
 import { resolveGlobPatterns } from '../../src/utils/glob';
+import { logger } from '../../src/utils/logger';
 
 // Mock fs first, before any other imports that might use it
 let mockExistingFiles: string[] = [];
@@ -53,11 +54,13 @@ describe('cli', () => {
   let originalArgv: string[];
   const mockOpen = jest.fn();
   let mockServe: jest.Mock;
+  const mockLogger = logger as jest.Mocked<typeof logger>;
 
   beforeEach(() => {
     cli = new CLI();
     originalArgv = process.argv;
     mockServe = serve as jest.Mock;
+    process.exitCode = undefined;
     // Reset the mock result for existsSync before each test
     setExistingFiles([]); // Default to empty for safety
     jest.clearAllMocks();
@@ -152,6 +155,31 @@ describe('cli', () => {
     return cli.run()
       .then(() => {
         expect(mockServe).toHaveBeenCalledWith({ directory: path.resolve('.') }, 8521, 'localhost', true);
+      });
+  });
+
+  it('should log the server URL without opening the browser when --no-open is specified', () => {
+    setExistsSyncResult(false);
+    process.argv = ['node', 'cli.ts', '--no-open', '--host', '0.0.0.0', '.'];
+
+    return cli.run()
+      .then(() => {
+        expect(mockServe).toHaveBeenCalledWith({ directory: path.resolve('.') }, 8521, '0.0.0.0', false);
+        expect(mockLogger.log).toHaveBeenCalledWith('CLI', '🌐 Server running at http://localhost:8521');
+        expect(mockOpen).not.toHaveBeenCalled();
+      });
+  });
+
+  it('should log an error and set exitCode when serve fails', () => {
+    setExistsSyncResult(false);
+    mockServe.mockRejectedValueOnce(new Error('boom'));
+    process.argv = ['node', 'cli.ts', '.'];
+
+    return cli.run()
+      .then(() => {
+        expect(mockLogger.error).toHaveBeenCalledWith('❌ Failed to start server: boom');
+        expect(process.exitCode).toBe(1);
+        expect(mockOpen).not.toHaveBeenCalled();
       });
   });
 

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -1,0 +1,17 @@
+describe('index', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it('instantiates CLI and runs it', async () => {
+    const run = jest.fn();
+    const CLI = jest.fn(() => ({ run }));
+
+    jest.doMock('../../src/cli', () => ({ CLI }));
+
+    await import('../../src/index');
+
+    expect(CLI).toHaveBeenCalledTimes(1);
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/unit/server/routes/outline.test.ts
+++ b/test/unit/server/routes/outline.test.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs';
 import MarkdownIt from 'markdown-it';
 import path from 'path';
 import { outlineRouter } from '../../../../src/server/routes/outline';
+import { logger } from '../../../../src/utils/logger';
 
 // Mock the fs module
 jest.mock('fs', () => {
@@ -24,6 +25,11 @@ jest.mock('markdown-it', () => {
     }),
   }));
 });
+jest.mock('../../../../src/utils/logger', () => ({
+  logger: {
+    error: jest.fn(),
+  },
+}));
 describe('outline.ts', () => {
   beforeEach(() => {
     const mockedFs = fs as jest.Mocked<typeof import('fs')>;
@@ -31,6 +37,7 @@ describe('outline.ts', () => {
     mockedFs.existsSync.mockReset();
     mockedFs.existsSync.mockReturnValue(true);
     (MarkdownIt as jest.Mock).mockClear();
+    jest.mocked(logger.error).mockReset();
   });
 
   describe('outlineRouter', () => {
@@ -88,6 +95,20 @@ describe('outline.ts', () => {
       expect(response.text).toBe('[]');
 
       consoleErrorSpy.mockRestore();
+    });
+
+    it('should return 500 when outline generation fails', async () => {
+      const error = new Error('Failed to read markdown');
+      const mockedFs = fs as jest.Mocked<typeof import('fs')>;
+      mockedFs.readFileSync.mockImplementationOnce(() => {
+        throw error;
+      });
+
+      const response = await request(app).get('/api/outline?filePath=broken.md');
+
+      expect(response.statusCode).toBe(500);
+      expect(response.text).toBe('Error getting outline.');
+      expect(logger.error).toHaveBeenCalledWith('Error getting outline for broken.md:', error);
     });
   });
 });

--- a/test/unit/server/routes/plantuml.test.ts
+++ b/test/unit/server/routes/plantuml.test.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import request from 'supertest';
 import { PassThrough } from 'stream';
 import { plantumlRouter } from '../../../../src/server/routes/plantuml';
+import { logger } from '../../../../src/utils/logger';
 
 const createPlantumlModule = (svg: string) => ({
   generate: jest.fn(() => {
@@ -10,6 +11,19 @@ const createPlantumlModule = (svg: string) => ({
 
     inputStream.on('finish', () => {
       outputStream.end(svg);
+    });
+
+    return { in: inputStream, out: outputStream };
+  }),
+});
+
+const createFailingPlantumlModule = (error: Error) => ({
+  generate: jest.fn(() => {
+    const inputStream = new PassThrough();
+    const outputStream = new PassThrough();
+
+    inputStream.on('finish', () => {
+      outputStream.emit('error', error);
     });
 
     return { in: inputStream, out: outputStream };
@@ -58,6 +72,26 @@ describe('plantuml.ts', () => {
       const svgBody = Buffer.isBuffer(payload) ? payload.toString() : payload;
       expect(svgBody).toBe('<svg>diagram</svg>');
       expect(plantumlModule.generate).toHaveBeenCalledWith({ format: 'svg' });
+    });
+
+    it('should return 500 when SVG generation fails', async () => {
+      const error = new Error('generation failed');
+      const errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => {});
+
+      plantumlModule = createFailingPlantumlModule(error);
+      app = express();
+      app.use(express.json());
+      app.use('/api/plantuml', plantumlRouter(plantumlModule));
+
+      const response = await request(app)
+        .post('/api/plantuml/svg')
+        .send({ diagram: '@startuml\nA --> B\n@enduml' });
+
+      expect(response.statusCode).toBe(500);
+      expect(response.text).toBe('Error generating PlantUML diagram.');
+      expect(errorSpy).toHaveBeenCalledWith('Error generating PlantUML diagram:', error);
+
+      errorSpy.mockRestore();
     });
   });
 });

--- a/test/unit/server/server.test.ts
+++ b/test/unit/server/server.test.ts
@@ -4,6 +4,7 @@ import { createApp, serve } from '../../../src/server/server';
 import { setupWatcher } from '../../../src/server/watcher';
 import { getConfig, saveConfig } from '../../../src/server/config';
 import { ServerContext } from '../../../src/server/context';
+import { logger } from '../../../src/utils/logger';
 
 jest.mock('express', () => {
   const mockUse = jest.fn();
@@ -316,6 +317,20 @@ describe('server.ts unit tests', () => {
       expect(app.listen).toHaveBeenCalledWith(3000, 'localhost');
       expect(setupWatcher).toHaveBeenCalledWith(context, server, 3000);
       expect(port).toBe(3000);
+    });
+
+    it('should log watched file count when file patterns are provided', async () => {
+      const context: ServerContext = {
+        directory: '/mock/directory',
+        filePatterns: ['README.md', 'docs/guide.md'],
+      };
+
+      await serve(context, 3000, 'localhost');
+
+      expect(logger.log).toHaveBeenCalledWith(
+        'Server',
+        '📄 Watching 2 files from glob patterns',
+      );
     });
 
     it('should reject on EADDRINUSE when autoPort is false', async () => {

--- a/test/unit/server/watcher.test.ts
+++ b/test/unit/server/watcher.test.ts
@@ -55,7 +55,8 @@ describe('watcher.ts unit tests', () => {
 
     mockDirectoryWatcher = {
       on: jest.fn().mockReturnThis(),
-      close: jest.fn(),
+      close: jest.fn().mockResolvedValue(undefined),
+      unwatch: jest.fn(),
     } as unknown as FSWatcher;
     (chokidar.watch as jest.Mock).mockReturnValue(mockDirectoryWatcher);
 
@@ -197,6 +198,11 @@ describe('watcher.ts unit tests', () => {
       expect(chokidar.watch).not.toHaveBeenCalled();
     });
 
+    it('should log error if WebSocket message payload is invalid JSON', () => {
+      onClientMessage('{invalid-json');
+      expect(logger.error).toHaveBeenCalledWith('🚫 Error parsing WebSocket message:', expect.any(Error));
+    });
+
     it('should log error if content watcher encounters an error', () => {
       (chokidar.watch as jest.Mock).mockReturnValueOnce(mockContentWatcher);
       onClientMessage(JSON.stringify({ type: 'watch-file', filePath: '/mock/file.md' }));
@@ -245,6 +251,23 @@ describe('watcher.ts unit tests', () => {
 
       expect(logger.error).toHaveBeenCalledWith('🚫 Error watching directory:', expect.any(Error));
       expect(logger.error).toHaveBeenCalledWith('Livereload will be disabled');
+    });
+
+    it('should close directory watcher and log EMFILE guidance on watcher error event', async () => {
+      const onErrorCallback = (mockDirectoryWatcher.on as jest.Mock).mock.calls.find(call => call[0] === 'error')[1];
+      const error = Object.assign(new Error('Too many open files'), { code: 'EMFILE' });
+
+      onErrorCallback(error);
+      await Promise.resolve();
+
+      expect(mockDirectoryWatcher.unwatch).toHaveBeenCalledWith('/mock/directory');
+      expect(mockDirectoryWatcher.close).toHaveBeenCalled();
+      expect(logger.log).toHaveBeenCalledWith('Livereload', 'Directory watcher closed');
+      expect(logger.error).toHaveBeenCalledWith('🚫 Error watching directory:', error);
+      expect(logger.error).toHaveBeenCalledWith('Livereload will be disabled');
+      expect(logger.error).toHaveBeenCalledWith(
+        'This error is likely caused by too many open files. Try increasing the ulimit.',
+      );
     });
   });
 

--- a/test/unit/utils/logger.test.ts
+++ b/test/unit/utils/logger.test.ts
@@ -1,0 +1,83 @@
+const flushAsyncWork = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+const loadLogger = () => {
+  jest.unmock('../../../src/utils/logger');
+  return (jest.requireActual('../../../src/utils/logger') as typeof import('../../../src/utils/logger')).logger;
+};
+
+describe('logger', () => {
+  let logSpy: jest.SpiedFunction<typeof console.log>;
+  let errorSpy: jest.SpiedFunction<typeof console.error>;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('shows the logo when silent mode is disabled', () => {
+    const logger = loadLogger();
+
+    logger.showLogo();
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0][0]).toContain('_');
+  });
+
+  it('suppresses logo and tagged logs when silent mode is enabled', async () => {
+    const logger = loadLogger();
+
+    logger.setSilent(true);
+    logger.showLogo();
+    logger.log('CLI', 'hidden message');
+    await flushAsyncWork();
+
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    'CLI',
+    'Server',
+    'Livereload',
+    'Announcement',
+    'Other',
+  ])('writes the padded tag for %s logs', async (tag) => {
+    const logger = loadLogger();
+    const prefix = ` ${tag.padEnd(12, ' ')} `;
+
+    logger.log(tag as never, 'plain message');
+    await flushAsyncWork();
+
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining(`${prefix} plain message`));
+  });
+
+  it('formats URLs as clickable links and forwards extra arguments', async () => {
+    const logger = loadLogger();
+    const url = 'https://example.com/docs';
+    const meta = { ok: true };
+
+    logger.log('Announcement', `Open ${url}`, meta);
+    await flushAsyncWork();
+
+    expect(logSpy.mock.calls[0][0]).toContain('Announcement');
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining(`Open \x1b]8;;${url}\x1b\\${url}\x1b]8;;\x1b\\`),
+      meta,
+    );
+  });
+
+  it('writes styled errors to stderr', async () => {
+    const logger = loadLogger();
+    const detail = { code: 500 };
+
+    logger.error('something failed', detail);
+    await flushAsyncWork();
+
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Error'), 'something failed', detail);
+  });
+});

--- a/test/unit/utils/logger.test.ts
+++ b/test/unit/utils/logger.test.ts
@@ -1,4 +1,8 @@
 const flushAsyncWork = () => new Promise<void>((resolve) => setImmediate(resolve));
+const stripAnsi = (message: string) => {
+  const escape = String.fromCharCode(27);
+  return message.replace(new RegExp(`${escape}\\[[0-9;]*m`, 'g'), '');
+};
 
 const loadLogger = () => {
   jest.unmock('../../../src/utils/logger');
@@ -53,7 +57,7 @@ describe('logger', () => {
     logger.log(tag as never, 'plain message');
     await flushAsyncWork();
 
-    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining(`${prefix} plain message`));
+    expect(stripAnsi(logSpy.mock.calls[0][0] as string)).toContain(`${prefix} plain message`);
   });
 
   it('formats URLs as clickable links and forwards extra arguments', async () => {


### PR DESCRIPTION
## Summary
- Significantly improve test coverage across CLI, server, and frontend (backend 99%+, key frontend modules at 100%)
- Rework `Layout` tests with a child-component mocking approach to shrink the bloated snapshot
- Add: `App.behavior` / `api` / `index` (both frontend and backend) / `store` / `useTheme` / `useSyntaxHighlighterTheme` / `useSettingsForm` / `logger` / error paths for each router
- Replace the fragile dummy-`open` PATH override in the CLI e2e test with the existing `--no-open` flag, eliminating the risk of accidentally launching a real browser
- Remove the empty `.codex` file that had been committed by mistake

## Test plan
- [x] `npm run test` (backend, 119 tests / 13 suites pass)
- [x] `npm run test:frontend` (frontend, 292 tests / 55 suites pass)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Expanded unit and end-to-end test coverage for app initialization, settings management, file navigation, markdown rendering, diagram generation, and CLI operations.
  * Added tests for error handling, offline scenarios, localStorage persistence, and mobile-responsive behavior across all major features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->