### PR TITLE
fix(server): normalize file tree paths to POSIX separators

### DIFF
--- a/src/server/routes/filetree.ts
+++ b/src/server/routes/filetree.ts
@@ -9,6 +9,8 @@ import { resolveGlobPatterns } from '../../utils/glob';
 type FileTreeItem = { path: string, status: string, isDirectory?: boolean } | { [key: string]: FileTree };
 type FileTree = FileTreeItem[];
 
+const toPosixPath = (p: string): string => p.split(path.sep).join('/');
+
 export const fileTreeRouter = (context: ServerContext): Router => {
   const { directory } = context;
   const router = Router();
@@ -72,8 +74,9 @@ const buildFileTreeFromPatterns = (
   sorted.forEach(filePath => {
     const dirPath = path.dirname(filePath);
     const targetTree = dirPath === '.' ? root : getOrCreateDir(dirPath);
-    const status = getGitStatus(filePath, gitStatus);
-    targetTree.push({ path: filePath, status });
+    const posixPath = toPosixPath(filePath);
+    const status = getGitStatus(posixPath, gitStatus);
+    targetTree.push({ path: posixPath, status });
   });
 
   return root;
@@ -108,8 +111,9 @@ const getFileTree = async (
         tree.push({ [entry.name]: subTree });
       }
     } else if (entry.name.endsWith('.md') || entry.name.endsWith('.markdown')) {
-      const status = getGitStatus(entryPath, gitStatus);
-      tree.push({ path: entryPath, status });
+      const posixPath = toPosixPath(entryPath);
+      const status = getGitStatus(posixPath, gitStatus);
+      tree.push({ path: posixPath, status });
     }
   }
   return tree;

--- a/test/unit/server/routes/filetree.test.ts
+++ b/test/unit/server/routes/filetree.test.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import fs from 'fs';
+import path from 'path';
 import request from 'supertest';
 import { fileTreeRouter } from '../../../../src/server/routes/filetree';
 
@@ -112,6 +113,42 @@ describe('filetree.ts', () => {
       const response = await request(app).get('/api/filetree');
       expect(response.statusCode).toBe(200);
       expect(fs.readdirSync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('path separator normalization (Windows compatibility)', () => {
+    let app: express.Application;
+    const mockDirectory = '/mock/base/dir';
+    const originalSep = path.sep;
+
+    beforeEach(() => {
+      // Simulate Windows path separator
+      Object.defineProperty(path, 'sep', { value: '\\', configurable: true });
+      app = express();
+      app.use('/api/filetree', fileTreeRouter({
+        directory: mockDirectory,
+        filePatterns: ['internal\\Benchmark\\plan.md', 'docs\\guide.md'],
+      }));
+    });
+
+    afterEach(() => {
+      Object.defineProperty(path, 'sep', { value: originalSep, configurable: true });
+    });
+
+    it('should normalize backslash separators to forward slashes in file paths', async () => {
+      const response = await request(app).get('/api/filetree');
+      expect(response.statusCode).toBe(200);
+      const flattenPaths = (
+        tree: unknown[],
+      ): string[] => tree.flatMap(item => {
+        if (item && typeof item === 'object' && 'path' in item) return [(item as { path: string }).path];
+        const value = Object.values(item as object)[0] as unknown[];
+        return flattenPaths(value);
+      });
+      const paths = flattenPaths(response.body.fileTree);
+      paths.forEach(p => expect(p).not.toContain('\\'));
+      expect(paths).toContain('internal/Benchmark/plan.md');
+      expect(paths).toContain('docs/guide.md');
     });
   });
 });


### PR DESCRIPTION
## Summary
- Tree view leaf nodes on Windows displayed the full path (e.g. `internal\Benchmark\plan.md`) instead of just the filename, because the backend emitted OS-native separators while the frontend split on `/`.
- Normalize all `path` values returned from `/api/filetree` to POSIX (`/`) form via a `toPosixPath` helper. Backend consumers (`/api/markdown`, `/api/outline`, `/api/diff`) all go through `path.join(directory, filePath)` or git CLI, both of which accept POSIX paths on Windows.
- Also fixes `getGitStatus`, which compared OS-native `entryPath` against git's POSIX-format `f.path` and would never match on Windows.

Closes #677

## Test plan
- [x] `npx jest test/unit/server/routes/filetree.test.ts` — all 6 tests pass, including new regression test that simulates `path.sep = '\\'` and verifies returned paths contain no backslashes.
- [ ] Manual verification on Windows: tree view leaf labels show only the filename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)