### PR TITLE
docs: add Support section with star and share links

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,9 +121,9 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for details — we'd love to have your 
 If you find this project useful, please consider:
 
 - ⭐️ [Star on GitHub](https://github.com/unhappychoice/mdts)
-- 🐦 [Share on X](https://x.com/intent/post?text=mdts%3A%20a%20zero-config%20local%20markdown%20preview%20server.%20%60npx%20mdts%60%20and%20you%27re%20done%20%F0%9F%93%9D&url=https%3A//github.com/unhappychoice/mdts&hashtags=mdts)
-- 🦋 [Share on Bluesky](https://bsky.app/intent/compose?text=mdts%3A%20a%20zero-config%20local%20markdown%20preview%20server.%20%60npx%20mdts%60%20and%20you%27re%20done%20%F0%9F%93%9D%20%23mdts%20https%3A//github.com/unhappychoice/mdts)
-- 🧵 [Share on Threads](https://www.threads.net/intent/post?text=mdts%3A%20a%20zero-config%20local%20markdown%20preview%20server.%20%60npx%20mdts%60%20and%20you%27re%20done%20%F0%9F%93%9D%20%23mdts%20https%3A//github.com/unhappychoice/mdts)
+- 🐦 [Share on X](https://x.com/intent/post?text=mdts%3A%20a%20zero-config%20local%20markdown%20preview%20server.%20%60npx%20mdts%60%20and%20you%27re%20done%20%F0%9F%93%9D&url=https%3A//github.com/unhappychoice/mdts&hashtags=mdts,markdown,devtools,npm)
+- 🦋 [Share on Bluesky](https://bsky.app/intent/compose?text=mdts%3A%20a%20zero-config%20local%20markdown%20preview%20server.%20%60npx%20mdts%60%20and%20you%27re%20done%20%F0%9F%93%9D%20%23mdts%20%23markdown%20%23devtools%20%23npm%20https%3A//github.com/unhappychoice/mdts)
+- 🧵 [Share on Threads](https://www.threads.net/intent/post?text=mdts%3A%20a%20zero-config%20local%20markdown%20preview%20server.%20%60npx%20mdts%60%20and%20you%27re%20done%20%F0%9F%93%9D%20%23mdts%20%23markdown%20%23devtools%20%23npm%20https%3A//github.com/unhappychoice/mdts)
 - 💼 [Share on LinkedIn](https://www.linkedin.com/sharing/share-offsite/?url=https%3A//github.com/unhappychoice/mdts)
 - 📘 [Share on Facebook](https://www.facebook.com/sharer/sharer.php?u=https%3A//github.com/unhappychoice/mdts)
 - 🟧 [Submit to Hacker News](https://news.ycombinator.com/submitlink?u=https%3A//github.com/unhappychoice/mdts&t=mdts%3A%20a%20zero-config%20local%20markdown%20preview%20server.%20%60npx%20mdts%60%20and%20you%27re%20done%20%F0%9F%93%9D)

--- a/README.md
+++ b/README.md
@@ -115,3 +115,17 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for details — we'd love to have your 
 ## Author
 
 [@unhappychoice](https://unhappychoice.com)
+
+## Support
+
+If you find this project useful, please consider:
+
+- ⭐️ [Star on GitHub](https://github.com/unhappychoice/mdts)
+- 🐦 [Share on X](https://x.com/intent/post?text=mdts%3A%20a%20zero-config%20local%20markdown%20preview%20server.%20%60npx%20mdts%60%20and%20you%27re%20done%20%F0%9F%93%9D&url=https%3A//github.com/unhappychoice/mdts&hashtags=mdts)
+- 🦋 [Share on Bluesky](https://bsky.app/intent/compose?text=mdts%3A%20a%20zero-config%20local%20markdown%20preview%20server.%20%60npx%20mdts%60%20and%20you%27re%20done%20%F0%9F%93%9D%20%23mdts%20https%3A//github.com/unhappychoice/mdts)
+- 🧵 [Share on Threads](https://www.threads.net/intent/post?text=mdts%3A%20a%20zero-config%20local%20markdown%20preview%20server.%20%60npx%20mdts%60%20and%20you%27re%20done%20%F0%9F%93%9D%20%23mdts%20https%3A//github.com/unhappychoice/mdts)
+- 💼 [Share on LinkedIn](https://www.linkedin.com/sharing/share-offsite/?url=https%3A//github.com/unhappychoice/mdts)
+- 📘 [Share on Facebook](https://www.facebook.com/sharer/sharer.php?u=https%3A//github.com/unhappychoice/mdts)
+- 🟧 [Submit to Hacker News](https://news.ycombinator.com/submitlink?u=https%3A//github.com/unhappychoice/mdts&t=mdts%3A%20a%20zero-config%20local%20markdown%20preview%20server.%20%60npx%20mdts%60%20and%20you%27re%20done%20%F0%9F%93%9D)
+
+Every bit of support helps. Thanks!

--- a/README.md
+++ b/README.md
@@ -127,5 +127,7 @@ If you find this project useful, please consider:
 - 💼 [Share on LinkedIn](https://www.linkedin.com/sharing/share-offsite/?url=https%3A//github.com/unhappychoice/mdts)
 - 📘 [Share on Facebook](https://www.facebook.com/sharer/sharer.php?u=https%3A//github.com/unhappychoice/mdts)
 - 🟧 [Submit to Hacker News](https://news.ycombinator.com/submitlink?u=https%3A//github.com/unhappychoice/mdts&t=mdts%3A%20a%20zero-config%20local%20markdown%20preview%20server.%20%60npx%20mdts%60%20and%20you%27re%20done%20%F0%9F%93%9D)
+- 💬 Drop it into your Discord server or developer chat
+- ✍️ Write about it on your blog or in a newsletter
 
 Every bit of support helps. Thanks!


### PR DESCRIPTION
## Summary

- Add a Support section at the end of README with links to star the repo and share it on X, Bluesky, Threads, LinkedIn, Facebook, and Hacker News.
- Each share link is pre-filled with a short pitch and the `#mdts` hashtag where supported.

## Test plan

- [x] README renders correctly on GitHub
- [ ] Each share link opens the target platform's composer with the expected text and URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project documentation with a new Support section encouraging community engagement through repository starring and social media sharing across multiple platforms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unhappychoice/mdts/pull/716)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->