### PR TITLE
docs: add integration recipes for common workflows

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,0 +1,219 @@
+---
+title: Integrations
+description: Integration recipes for using mdts with common tools and workflows
+category: Documentation
+tags:
+  - integrations
+  - raycast
+  - vscode
+  - git-hooks
+  - shell
+  - npm
+---
+
+# Integrations
+
+`mdts` is a CLI tool that fits naturally into a variety of developer workflows. This page provides copy-paste ready recipes for integrating `mdts` with popular tools.
+
+---
+
+## Raycast Script Command
+
+Add a Raycast script command to launch `mdts` on the directory you're currently working in.
+
+Create a file at `~/.raycast/scripts/open-mdts.sh`:
+
+```bash
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Preview Markdown (mdts)
+# @raycast.mode silent
+# @raycast.packageName Developer Tools
+
+# Optional parameters:
+# @raycast.icon 📝
+# @raycast.argument1 { "type": "directory", "placeholder": "Directory", "optional": true }
+
+DIR="${1:-$PWD}"
+npx mdts "$DIR"
+```
+
+Make it executable and add it to Raycast:
+
+```bash
+chmod +x ~/.raycast/scripts/open-mdts.sh
+```
+
+Then in Raycast: **Import Script Commands** → select the file. Now you can trigger it from the Raycast launcher with an optional directory argument (defaults to your current working directory).
+
+---
+
+## VS Code Task
+
+Add a task to `.vscode/tasks.json` so you can launch `mdts` from the Command Palette or bind it to a keyboard shortcut.
+
+```json
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Preview Markdown (mdts)",
+      "type": "shell",
+      "command": "npx mdts ${workspaceFolder}",
+      "presentation": {
+        "reveal": "silent",
+        "panel": "dedicated",
+        "focus": false
+      },
+      "problemMatcher": [],
+      "runOptions": {
+        "runOn": "default"
+      }
+    },
+    {
+      "label": "Preview Markdown — docs/ only",
+      "type": "shell",
+      "command": "npx mdts ${workspaceFolder}/docs",
+      "presentation": {
+        "reveal": "silent",
+        "panel": "dedicated"
+      },
+      "problemMatcher": []
+    }
+  ]
+}
+```
+
+**Bind to a keyboard shortcut** by adding this to `keybindings.json` (`Ctrl+Shift+P` → *Open Keyboard Shortcuts (JSON)*):
+
+```json
+{
+  "key": "ctrl+shift+m",
+  "command": "workbench.action.tasks.runTask",
+  "args": "Preview Markdown (mdts)"
+}
+```
+
+---
+
+## Shell Alias
+
+Add a short alias to your shell config for quick access from any directory.
+
+**Bash** (`~/.bashrc`) or **Zsh** (`~/.zshrc`):
+
+```bash
+# Open mdts in the current directory
+alias mdp="npx mdts ."
+
+# Open mdts in a specific directory, defaulting to current
+function mdpreview() {
+  npx mdts "${1:-.}"
+}
+```
+
+After adding, reload your shell:
+
+```bash
+source ~/.bashrc   # or source ~/.zshrc
+```
+
+Usage:
+
+```bash
+mdp                   # preview current directory
+mdpreview ./docs      # preview a specific folder
+```
+
+---
+
+## Git Hooks
+
+### post-commit: preview changed Markdown files
+
+This hook opens `mdts` after a commit if any Markdown files were changed. It extracts the directory of the first changed `.md` file and serves it.
+
+Create `.git/hooks/post-commit`:
+
+```bash
+#!/bin/bash
+
+# Get the list of changed .md files in the last commit
+CHANGED_MD=$(git diff-tree --no-commit-id -r --name-only HEAD | grep '\.md$')
+
+if [ -n "$CHANGED_MD" ]; then
+  # Serve the directory containing the first changed markdown file
+  FIRST_FILE=$(echo "$CHANGED_MD" | head -n 1)
+  DIR=$(dirname "$FIRST_FILE")
+  echo "mdts: opening preview for $DIR"
+  npx mdts "$DIR" &
+fi
+```
+
+Make it executable:
+
+```bash
+chmod +x .git/hooks/post-commit
+```
+
+### pre-commit: lint or validate Markdown (optional)
+
+If you want to run a Markdown linter before committing (e.g., `markdownlint`), here's a pattern that pairs well with `mdts`:
+
+```bash
+#!/bin/bash
+
+CHANGED_MD=$(git diff --cached --name-only | grep '\.md$')
+
+if [ -n "$CHANGED_MD" ]; then
+  if command -v markdownlint &>/dev/null; then
+    markdownlint $CHANGED_MD || exit 1
+  fi
+fi
+```
+
+---
+
+## npm Script
+
+Add `mdts` as a script in your `package.json` to make it accessible to all contributors without any global installs.
+
+```json
+{
+  "scripts": {
+    "docs": "mdts ./docs",
+    "docs:root": "mdts .",
+    "docs:watch": "mdts . --silent"
+  }
+}
+```
+
+Run with:
+
+```bash
+npm run docs           # serve the docs/ folder
+npm run docs:root      # serve everything from the project root
+```
+
+This is especially useful for monorepos or team projects where you want a consistent, documented way to preview documentation locally.
+
+---
+
+## Tips
+
+- Use `--no-open` if you want `mdts` to start silently without opening a browser tab automatically:
+  ```bash
+  npx mdts . --no-open
+  ```
+- Use `--port` to avoid conflicts when running multiple instances:
+  ```bash
+  npx mdts ./docs --port 8600
+  ```
+- Use `--glob` to narrow the file tree in large projects:
+  ```bash
+  npx mdts . -g 'docs/**/*.md' 'README.md'
+  ```
+
+See the [Advanced Configuration](./configuration.md) guide for more customization options.


### PR DESCRIPTION
Closes #484

## What this adds

This PR adds `docs/integrations.md` — a practical guide for integrating `mdts` into common developer workflows.

### Covered integrations

- **Raycast Script Command** — shell script to launch `npx mdts` from the Raycast launcher, with an optional directory argument
- **VS Code Task** — `tasks.json` entry to run mdts from the Command Palette, plus a `keybindings.json` snippet to bind it to a shortcut
- **Shell aliases** — bash/zsh alias (`mdp`) and a `mdpreview()` function for quick access from any directory
- **Git hooks** — a `post-commit` hook that auto-opens `mdts` on the directory of any changed Markdown files, and a `pre-commit` linting pattern
- **npm scripts** — `package.json` entries so any contributor can run `npm run docs` without a global install

All examples are copy-paste ready and follow the style of the existing docs. A tips section at the end covers `--no-open`, `--port`, and `--glob` for more advanced setups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive integration guide with copy-paste recipes for using the CLI in Raycast, VS Code tasks/shortcuts, shell aliases, Git hooks, and npm scripts.
  * Included practical tips for CLI flags (no-open, port, glob) and a link to advanced configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unhappychoice/mdts/pull/731?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->