### PR TITLE
fix(frontend): make inline code readable under default 'auto' syntax theme

### DIFF
--- a/packages/frontend/src/components/Content/MarkdownContent/MarkdownRenderer/MarkdownCode.tsx
+++ b/packages/frontend/src/components/Content/MarkdownContent/MarkdownRenderer/MarkdownCode.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 import { PrismAsyncLight } from 'react-syntax-highlighter';
-import { SYNTAX_HIGHLIGHTER_THEMES } from '../../../../constants';
-import { useSyntaxHighlighterTheme } from '../../../../hooks/useSyntaxHighlighterTheme';
+import { useSyntaxHighlighterTheme, useSyntaxHighlighterThemeMeta } from '../../../../hooks/useSyntaxHighlighterTheme';
 import { RootState } from '../../../../store/store';
 import MermaidRenderer from './MermaidRenderer';
 import PlantUMLRenderer from './PlantUMLRenderer';
@@ -16,6 +15,7 @@ interface MarkdownCodeProps {
 const MarkdownCode: React.FC<MarkdownCodeProps> = ({ inline, className, children, ...props }) => {
   const { fontFamilyMonospace, syntaxHighlighterTheme } = useSelector((state: RootState) => state.config);
   const syntaxHighlighterStyle = useSyntaxHighlighterTheme(syntaxHighlighterTheme);
+  const syntaxHighlighterThemeMeta = useSyntaxHighlighterThemeMeta(syntaxHighlighterTheme);
 
   const match = /language-(\w+)/.exec(className || '');
   if (match && match[1] === 'mermaid') {
@@ -43,11 +43,9 @@ const MarkdownCode: React.FC<MarkdownCodeProps> = ({ inline, className, children
       {...props}
       className={className}
       style={{
-        color: SYNTAX_HIGHLIGHTER_THEMES.find(theme => theme.value === syntaxHighlighterTheme)?.type === 'light'
-          ? 'rgba(0, 0, 0, .87)'
-          : '#fff',
+        color: syntaxHighlighterThemeMeta.type === 'light' ? 'rgba(0, 0, 0, .87)' : '#fff',
         fontFamily: fontFamilyMonospace,
-        backgroundColor: SYNTAX_HIGHLIGHTER_THEMES.find(theme => theme.value === syntaxHighlighterTheme)?.color,
+        backgroundColor: syntaxHighlighterThemeMeta.color,
         borderRadius: '4px',
       }}
     >

--- a/packages/frontend/src/hooks/useSyntaxHighlighterTheme.ts
+++ b/packages/frontend/src/hooks/useSyntaxHighlighterTheme.ts
@@ -44,6 +44,21 @@ import {
   xonokai,
   zTouch
 } from 'react-syntax-highlighter/dist/esm/styles/prism';
+import { SYNTAX_HIGHLIGHTER_THEMES } from '../constants';
+
+export const resolveSyntaxHighlighterThemeValue = (syntaxHighlighterTheme: string, mode: 'light' | 'dark'): string => {
+  if (syntaxHighlighterTheme === 'auto') {
+    return mode === 'dark' ? 'atomDark' : 'vs';
+  }
+  return syntaxHighlighterTheme;
+};
+
+export const useSyntaxHighlighterThemeMeta = (syntaxHighlighterTheme: string) => {
+  const theme = useTheme();
+  const resolved = resolveSyntaxHighlighterThemeValue(syntaxHighlighterTheme, theme.palette.mode);
+  return SYNTAX_HIGHLIGHTER_THEMES.find(t => t.value === resolved)
+    ?? SYNTAX_HIGHLIGHTER_THEMES.find(t => t.value === 'atomDark')!;
+};
 
 export const useSyntaxHighlighterTheme = (syntaxHighlighterTheme: string): object => {
   const theme = useTheme();
@@ -94,12 +109,6 @@ export const useSyntaxHighlighterTheme = (syntaxHighlighterTheme: string): objec
     zTouch,
   };
 
-  const getSyntaxHighlighterTheme = () => {
-    if (syntaxHighlighterTheme === 'auto') {
-      return theme.palette.mode === 'dark' ? atomDark : vs;
-    }
-    return themeMap[syntaxHighlighterTheme] || atomDark;
-  };
-
-  return getSyntaxHighlighterTheme();
+  const resolved = resolveSyntaxHighlighterThemeValue(syntaxHighlighterTheme, theme.palette.mode);
+  return themeMap[resolved] || atomDark;
 };

--- a/packages/frontend/src/hooks/useSyntaxHighlighterTheme.ts
+++ b/packages/frontend/src/hooks/useSyntaxHighlighterTheme.ts
@@ -46,6 +46,8 @@ import {
 } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import { SYNTAX_HIGHLIGHTER_THEMES } from '../constants';
 
+type SyntaxHighlighterThemeMeta = typeof SYNTAX_HIGHLIGHTER_THEMES[number];
+
 export const resolveSyntaxHighlighterThemeValue = (syntaxHighlighterTheme: string, mode: 'light' | 'dark'): string => {
   if (syntaxHighlighterTheme === 'auto') {
     return mode === 'dark' ? 'atomDark' : 'vs';
@@ -53,7 +55,7 @@ export const resolveSyntaxHighlighterThemeValue = (syntaxHighlighterTheme: strin
   return syntaxHighlighterTheme;
 };
 
-export const useSyntaxHighlighterThemeMeta = (syntaxHighlighterTheme: string): typeof SYNTAX_HIGHLIGHTER_THEMES[number] => {
+export const useSyntaxHighlighterThemeMeta = (syntaxHighlighterTheme: string): SyntaxHighlighterThemeMeta => {
   const theme = useTheme();
   const resolved = resolveSyntaxHighlighterThemeValue(syntaxHighlighterTheme, theme.palette.mode);
   return SYNTAX_HIGHLIGHTER_THEMES.find(t => t.value === resolved)

--- a/packages/frontend/src/hooks/useSyntaxHighlighterTheme.ts
+++ b/packages/frontend/src/hooks/useSyntaxHighlighterTheme.ts
@@ -53,7 +53,7 @@ export const resolveSyntaxHighlighterThemeValue = (syntaxHighlighterTheme: strin
   return syntaxHighlighterTheme;
 };
 
-export const useSyntaxHighlighterThemeMeta = (syntaxHighlighterTheme: string) => {
+export const useSyntaxHighlighterThemeMeta = (syntaxHighlighterTheme: string): typeof SYNTAX_HIGHLIGHTER_THEMES[number] => {
   const theme = useTheme();
   const resolved = resolveSyntaxHighlighterThemeValue(syntaxHighlighterTheme, theme.palette.mode);
   return SYNTAX_HIGHLIGHTER_THEMES.find(t => t.value === resolved)

--- a/packages/frontend/test/unit/components/Content/MarkdownContent/MarkdownRenderer/__snapshots__/MarkdownCode.test.tsx.snap
+++ b/packages/frontend/test/unit/components/Content/MarkdownContent/MarkdownRenderer/__snapshots__/MarkdownCode.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`MarkdownCode should render code block correctly 1`] = `
 exports[`MarkdownCode should render inline code correctly 1`] = `
 <DocumentFragment>
   <code
-    style="color: rgb(255, 255, 255); font-family: monospace; border-radius: 4px;"
+    style="color: rgb(255, 255, 255); font-family: monospace; background-color: rgb(29, 31, 33); border-radius: 4px;"
   >
     console.log("hello");
   </code>


### PR DESCRIPTION
## Summary
- Inline `<code>` and fenced code blocks without a language rendered with white text on a transparent background under the default config, making them unreadable on light themes (reported in #749).
- Root cause: `MarkdownCode.tsx` looked up theme metadata directly in `SYNTAX_HIGHLIGHTER_THEMES`, which has no entry for the default value `'auto'` (nor for unknown values), so both `color` and `backgroundColor` resolved to undefined/white.
- Introduce `resolveSyntaxHighlighterThemeValue` and `useSyntaxHighlighterThemeMeta` in `useSyntaxHighlighterTheme.ts`, resolving `'auto'` to `'vs'` / `'atomDark'` based on the active MUI palette mode and falling back to `'atomDark'` for unknown values.
- `useSyntaxHighlighterTheme` itself now shares the same resolver, removing the duplicated `'auto'` branch.

## Test plan
- [x] `npx jest test/unit/components/Content/MarkdownContent/MarkdownRenderer/MarkdownCode.test.tsx` (4 passed, 1 snapshot updated to include the resolved background color)
- [x] Full frontend `npx jest --selectProjects test` shows no new failures (the 3 pre-existing `SettingsDialog` snapshot failures are MUI emotion hash churn unrelated to this change and also fail on `main`)
- [ ] Manual: open a Markdown file containing inline code and a fenced block without a language under the default config, in both light and dark system color schemes, and confirm the code renders with proper contrast.

Fixes #749

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized and simplified syntax-highlighter theme resolution for more consistent theming across light/dark modes.
* **Bug Fixes / UX**
  * Inline code and code blocks now use improved theme metadata, yielding more accurate foreground/background colors and better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->