### PR TITLE
feat: add open in editor action

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "markdown-it": "^14.1.0",
         "node-plantuml-back": "^1.1.4",
         "open": "^11.0.0",
+        "open-editor": "^6.0.0",
         "plantuml": "^0.0.2",
         "plantuml-encoder": "^1.4.0",
         "simple-git": "^3.28.0",
@@ -3422,6 +3423,12 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "license": "MIT"
+    },
     "node_modules/@simple-git/args-pathspec": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@simple-git/args-pathspec/-/args-pathspec-1.0.3.tgz",
@@ -3441,6 +3448,18 @@
       "version": "0.34.38",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
@@ -6766,6 +6785,18 @@
         "node": ">=4.3.0 <5.0.0 || >=5.10"
       }
     },
+    "node_modules/env-editor": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/env-editor/-/env-editor-1.3.0.tgz",
+      "integrity": "sha512-EqiD/j01PooUbeWk+etUo2TWoocjoxMfGNYpS9e47glIJ5r8WepycIki+LCbonFbPdwlqY5ETeSTAJVMih4z4w==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/errno": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
@@ -7423,6 +7454,21 @@
       "deprecated": "This module is no longer supported.",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -8506,6 +8552,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -8547,6 +8605,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-windows": {
@@ -10097,6 +10167,21 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/line-column-path": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/line-column-path/-/line-column-path-4.0.0.tgz",
+      "integrity": "sha512-Zvpvd56i9FRV5kaJFiiY1t+FNMEH+dGEaLyQprqKlGHBAxJXmdSk+8tVsh6b9YlxbfyyuLrhJCkzwB+AmOBZ0g==",
+      "license": "MIT",
+      "dependencies": {
+        "unicorn-magic": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "dev": true,
@@ -11333,6 +11418,139 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/open-editor": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/open-editor/-/open-editor-6.0.0.tgz",
+      "integrity": "sha512-LGd2Xn6NvFlbx/lg/HK69w6Dbg+21MzJzcPDPQRgDRqc+qiR+2/SN99rzZSo7Qa1ck1hcGYig0CAo53cmXCE0w==",
+      "license": "MIT",
+      "dependencies": {
+        "env-editor": "^1.3.0",
+        "execa": "^9.6.0",
+        "line-column-path": "^4.0.0",
+        "open": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open-editor/node_modules/execa": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/open-editor/node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open-editor/node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/open-editor/node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open-editor/node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open-editor/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open-editor/node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open-editor/node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "dev": true,
@@ -11459,6 +11677,18 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -11847,6 +12077,21 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/process": {
@@ -12776,7 +13021,6 @@
     },
     "node_modules/signal-exit": {
       "version": "4.1.0",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -14150,6 +14394,18 @@
         "node": ">=4"
       }
     },
+    "node_modules/unicorn-magic": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
+      "integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/union-value": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -15399,6 +15655,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "markdown-it": "^14.1.0",
     "node-plantuml-back": "^1.1.4",
     "open": "^11.0.0",
+    "open-editor": "^6.0.0",
     "plantuml": "^0.0.2",
     "plantuml-encoder": "^1.4.0",
     "simple-git": "^3.28.0",

--- a/packages/frontend/src/components/Content/MarkdownContent/MarkdownContent.tsx
+++ b/packages/frontend/src/components/Content/MarkdownContent/MarkdownContent.tsx
@@ -1,6 +1,6 @@
-import { ArticleOutlined } from '@mui/icons-material';
-import { Box, Chip, Typography } from '@mui/material';
-import React, { useEffect } from 'react';
+import { ArticleOutlined, EditOutlined } from '@mui/icons-material';
+import { Box, Chip, IconButton, Tooltip, Typography } from '@mui/material';
+import React, { useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useFrontmatter } from '../../../hooks/useFrontmatter';
 import useIsMobile from '../../../hooks/useIsMobile';
@@ -66,6 +66,22 @@ const MarkdownContent: React.FC<MarkdownContentProps> = ({ scrollToId, onDirecto
         : '🎉 Welcome to mdts!';
 
   const hasFrontmatter = Object.keys(frontmatter).length > 0;
+  const handleOpenInEditor = useCallback(async () => {
+    if (!currentPath) return;
+
+    try {
+      const response = await fetch('/api/open-editor', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ filePath: currentPath }),
+      });
+      if (!response.ok) {
+        throw new Error(`Failed to open editor: ${response.status}`);
+      }
+    } catch (openEditorError) {
+      console.error(openEditorError);
+    }
+  }, [currentPath]);
 
   if (error) {
     return <ErrorView error={error} />;
@@ -95,6 +111,18 @@ const MarkdownContent: React.FC<MarkdownContentProps> = ({ scrollToId, onDirecto
         <Typography variant={isMobile ? 'h5' : 'h4'} gutterBottom sx={{ mb: 0, wordBreak: 'break-word' }}>
           {displayFileName}
         </Typography>
+        {currentPath && (
+          <Tooltip title="Open in editor">
+            <IconButton
+              aria-label="open in editor"
+              onClick={handleOpenInEditor}
+              size={isMobile ? 'small' : 'medium'}
+              sx={{ ml: 1 }}
+            >
+              <EditOutlined />
+            </IconButton>
+          </Tooltip>
+        )}
       </Box>
       {frontmatter.tags && Array.isArray(frontmatter.tags) && frontmatter.tags.length > 0 && (
         <Box sx={{ display: 'flex', gap: 1, mb: 2 }}>

--- a/src/server/routes/open-editor.ts
+++ b/src/server/routes/open-editor.ts
@@ -1,0 +1,70 @@
+import { Router } from 'express';
+import * as fs from 'fs';
+import path from 'path';
+import { logger } from '../../utils/logger';
+import { ServerContext } from '../context';
+
+type EditorTarget = {
+  file: string;
+  line?: number;
+  column?: number;
+};
+
+type OpenEditorFn = (files: readonly EditorTarget[]) => Promise<void>;
+
+const defaultOpenEditor: OpenEditorFn = async (files) => {
+  const { default: openEditor } = await import('open-editor');
+  await openEditor(files);
+};
+
+const isInsideDirectory = (baseDirectory: string, targetPath: string): boolean => {
+  const relativePath = path.relative(baseDirectory, targetPath);
+  return relativePath === '' || (!relativePath.startsWith('..') && !path.isAbsolute(relativePath));
+};
+
+const normalizePositiveInteger = (value: unknown): number | undefined => {
+  if (value === undefined || value === null) return undefined;
+  const parsedValue = Number(value);
+  if (!Number.isInteger(parsedValue) || parsedValue < 1) return undefined;
+  return parsedValue;
+};
+
+export const openEditorRouter = (
+  context: ServerContext,
+  openEditor: OpenEditorFn = defaultOpenEditor,
+): Router => {
+  const { directory } = context;
+  const router = Router();
+
+  router.post('/', async (req, res) => {
+    const { filePath } = req.body ?? {};
+    if (typeof filePath !== 'string' || filePath.trim() === '') {
+      return res.status(400).json({ error: 'filePath is required' });
+    }
+
+    const absoluteFilePath = path.resolve(directory, filePath);
+    if (!isInsideDirectory(directory, absoluteFilePath)) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+
+    if (!fs.existsSync(absoluteFilePath)) {
+      return res.status(404).json({ error: 'File not found' });
+    }
+
+    if (fs.statSync(absoluteFilePath).isDirectory()) {
+      return res.status(400).json({ error: 'Cannot open a directory in editor' });
+    }
+
+    try {
+      const line = normalizePositiveInteger(req.body.line);
+      const column = normalizePositiveInteger(req.body.column);
+      await openEditor([{ file: absoluteFilePath, line, column }]);
+      res.status(204).send();
+    } catch (error) {
+      logger.error(`Failed to open ${absoluteFilePath} in editor:`, error);
+      res.status(500).json({ error: 'Failed to open editor' });
+    }
+  });
+
+  return router;
+};

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -9,6 +9,7 @@ import { getConfig, saveConfig } from './config';
 import { setupWatcher } from './watcher';
 import { diffRouter, diffPrevRouter } from './routes/diff';
 import { plantumlRouter } from './routes/plantuml';
+import { openEditorRouter } from './routes/open-editor';
 
 const MAX_PORT_RETRIES = 10;
 
@@ -72,6 +73,7 @@ export const createApp = (
   app.use('/api/diff-prev', diffPrevRouter(context));
   app.use('/api/diff', diffRouter(context));
   app.use('/api/plantuml', plantumlRouter());
+  app.use('/api/open-editor', openEditorRouter(context));
   app.get('/api/config', (req, res) => {
     res.json(getConfig());
   });
@@ -148,4 +150,3 @@ export const createApp = (
 
   return app;
 };
-

--- a/test/unit/server/routes/open-editor.test.ts
+++ b/test/unit/server/routes/open-editor.test.ts
@@ -1,0 +1,102 @@
+import express from 'express';
+import * as fs from 'fs';
+import path from 'path';
+import request from 'supertest';
+import { openEditorRouter } from '../../../../src/server/routes/open-editor';
+
+jest.mock('fs', () => ({
+  ...jest.requireActual('fs'),
+  existsSync: jest.fn(),
+  statSync: jest.fn(),
+}));
+
+describe('openEditorRouter', () => {
+  const mockDirectory = path.resolve('D:/mock/base/dir');
+  const mockOpenEditor = jest.fn();
+  let app: express.Application;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (fs.existsSync as jest.Mock).mockReturnValue(true);
+    (fs.statSync as jest.Mock).mockReturnValue({ isDirectory: () => false });
+
+    app = express();
+    app.use(express.json());
+    app.use('/api/open-editor', openEditorRouter({ directory: mockDirectory }, mockOpenEditor));
+  });
+
+  it('should require filePath', async () => {
+    const response = await request(app).post('/api/open-editor').send({});
+
+    expect(response.statusCode).toBe(400);
+    expect(response.body).toEqual({ error: 'filePath is required' });
+    expect(mockOpenEditor).not.toHaveBeenCalled();
+  });
+
+  it('should prevent path traversal', async () => {
+    const response = await request(app).post('/api/open-editor').send({ filePath: '../secret.md' });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.body).toEqual({ error: 'Forbidden' });
+    expect(mockOpenEditor).not.toHaveBeenCalled();
+  });
+
+  it('should return 404 for missing files', async () => {
+    (fs.existsSync as jest.Mock).mockReturnValue(false);
+
+    const response = await request(app).post('/api/open-editor').send({ filePath: 'missing.md' });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.body).toEqual({ error: 'File not found' });
+    expect(mockOpenEditor).not.toHaveBeenCalled();
+  });
+
+  it('should reject directories', async () => {
+    (fs.statSync as jest.Mock).mockReturnValue({ isDirectory: () => true });
+
+    const response = await request(app).post('/api/open-editor').send({ filePath: 'docs' });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.body).toEqual({ error: 'Cannot open a directory in editor' });
+    expect(mockOpenEditor).not.toHaveBeenCalled();
+  });
+
+  it('should open files in the editor', async () => {
+    mockOpenEditor.mockResolvedValue(undefined);
+
+    const response = await request(app)
+      .post('/api/open-editor')
+      .send({ filePath: 'docs/readme.md', line: 4, column: 2 });
+
+    expect(response.statusCode).toBe(204);
+    expect(mockOpenEditor).toHaveBeenCalledWith([{
+      file: path.resolve(mockDirectory, 'docs/readme.md'),
+      line: 4,
+      column: 2,
+    }]);
+  });
+
+  it('should ignore invalid line and column values', async () => {
+    mockOpenEditor.mockResolvedValue(undefined);
+
+    const response = await request(app)
+      .post('/api/open-editor')
+      .send({ filePath: 'docs/readme.md', line: 0, column: 'invalid' });
+
+    expect(response.statusCode).toBe(204);
+    expect(mockOpenEditor).toHaveBeenCalledWith([{
+      file: path.resolve(mockDirectory, 'docs/readme.md'),
+      line: undefined,
+      column: undefined,
+    }]);
+  });
+
+  it('should return 500 when opening the editor fails', async () => {
+    mockOpenEditor.mockRejectedValue(new Error('editor failed'));
+
+    const response = await request(app).post('/api/open-editor').send({ filePath: 'docs/readme.md' });
+
+    expect(response.statusCode).toBe(500);
+    expect(response.body).toEqual({ error: 'Failed to open editor' });
+  });
+});


### PR DESCRIPTION
## Summary

- Add an `/api/open-editor` endpoint backed by `open-editor`
- Validate requested paths stay inside the mounted directory before launching the editor
- Add an editor button to the markdown content header
- Cover success and error cases for the new route

Closes #37

## Verification

- Ran `git diff --check`
- Ran targeted ESLint for the new server route, server wiring, route test, and markdown content component
- Ran root `tsc -p tsconfig.json --noEmit`
- Ran focused Jest coverage for `open-editor.test.ts`: 1 suite / 7 tests passed
- Ran frontend webpack build directly through `webpack-cli/bin/cli.js`