### PR TITLE
feat: add full text search

### DIFF
--- a/packages/frontend/src/components/LeftPane/ContentSearchResults.tsx
+++ b/packages/frontend/src/components/LeftPane/ContentSearchResults.tsx
@@ -1,0 +1,98 @@
+import SearchOutlined from '@mui/icons-material/SearchOutlined';
+import { Box, CircularProgress, List, ListItemButton, ListItemText, Typography } from '@mui/material';
+import React, { useCallback } from 'react';
+import { ContentSearchResult } from '../../store/slices/fileTreeSlice';
+
+interface ContentSearchResultsProps {
+  searchQuery: string;
+  results: ContentSearchResult[];
+  loading: boolean;
+  error: string | null;
+  onFileSelect: (path: string) => void;
+}
+
+const MIN_CONTENT_SEARCH_LENGTH = 2;
+
+interface ContentSearchResultItemProps {
+  result: ContentSearchResult;
+  onFileSelect: (path: string) => void;
+}
+
+const ContentSearchResultItem: React.FC<ContentSearchResultItemProps> = ({ result, onFileSelect }) => {
+  const handleClick = useCallback(() => {
+    onFileSelect(result.path);
+  }, [onFileSelect, result.path]);
+
+  return (
+    <ListItemButton
+      onClick={handleClick}
+      sx={{ borderRadius: 1, alignItems: 'flex-start', py: 0.5 }}
+    >
+      <SearchOutlined sx={{ fontSize: 16, mr: 1, mt: 0.25, color: 'text.secondary' }} />
+      <ListItemText
+        primary={
+          <Typography variant="body2" noWrap sx={{ fontSize: '0.8125rem' }}>
+            {result.path}
+          </Typography>
+        }
+        secondary={
+          <Box component="span" sx={{ display: 'block' }}>
+            <Typography component="span" variant="caption" color="text.secondary" sx={{ display: 'block' }}>
+              Line {result.line}
+            </Typography>
+            <Typography component="span" variant="caption" color="text.secondary" noWrap sx={{ display: 'block' }}>
+              {result.preview}
+            </Typography>
+          </Box>
+        }
+      />
+    </ListItemButton>
+  );
+};
+
+const ContentSearchResults: React.FC<ContentSearchResultsProps> = ({
+  searchQuery,
+  results,
+  loading,
+  error,
+  onFileSelect,
+}) => {
+  if (searchQuery.trim().length < MIN_CONTENT_SEARCH_LENGTH) return null;
+
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', alignItems: 'center', px: 2, pb: 1, gap: 1 }}>
+        <CircularProgress size={14} />
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Typography role="alert" variant="caption" color="error" sx={{ display: 'block', px: 2, pb: 1 }}>
+        Search failed
+      </Typography>
+    );
+  }
+
+  if (results.length === 0) return null;
+
+  return (
+    <Box sx={{ px: 1, pb: 1 }}>
+      <Typography variant="caption" color="text.secondary" sx={{ display: 'block', px: 1, pb: 0.5 }}>
+        Content matches
+      </Typography>
+      <List dense disablePadding sx={{ maxHeight: 240, overflow: 'auto' }}>
+        {results.map((result) => (
+          <ContentSearchResultItem
+            key={`${result.path}:${result.line}:${result.preview}`}
+            result={result}
+            onFileSelect={onFileSelect}
+          />
+        ))}
+      </List>
+    </Box>
+  );
+};
+
+export default ContentSearchResults;

--- a/packages/frontend/src/components/LeftPane/FileTree.tsx
+++ b/packages/frontend/src/components/LeftPane/FileTree.tsx
@@ -3,13 +3,16 @@ import React, { useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import useIsMobile from '../../hooks/useIsMobile';
 import {
+  clearContentSearchResults,
   expandAllNodes,
+  fetchContentSearchResults,
   fetchFileTree,
   FileTreeItem,
   setExpandedNodes,
   setSearchQuery
 } from '../../store/slices/fileTreeSlice';
 import { AppDispatch, RootState } from '../../store/store';
+import ContentSearchResults from './ContentSearchResults';
 import FileTreeContent from './FileTreeContent/FileTreeContent';
 import FileTreeHeader from './FileTreeHeader';
 import FileTreeSearch from './FileTreeSearch';
@@ -31,6 +34,9 @@ const FileTree: React.FC<FileTreeComponentProps> = ({ onFileSelect, isOpen, onTo
     loading,
     error,
     searchQuery,
+    contentSearchResults,
+    contentSearchLoading,
+    contentSearchError,
     expandedNodes
   } = useSelector((state: RootState) => state.fileTree);
 
@@ -44,6 +50,7 @@ const FileTree: React.FC<FileTreeComponentProps> = ({ onFileSelect, isOpen, onTo
 
   const handleClearSearch = useCallback(() => {
     dispatch(setSearchQuery(''));
+    dispatch(clearContentSearchResults());
   }, [dispatch]);
 
   const handleExpandAllClick = useCallback(() => {
@@ -86,6 +93,20 @@ const FileTree: React.FC<FileTreeComponentProps> = ({ onFileSelect, isOpen, onTo
     dispatch(setExpandedNodes(newExpanded));
   }, [searchQuery, filteredFileTree, dispatch]);
 
+  useEffect(() => {
+    const trimmedQuery = searchQuery.trim();
+    if (trimmedQuery.length < 2) {
+      dispatch(clearContentSearchResults());
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      dispatch(fetchContentSearchResults(trimmedQuery));
+    }, 250);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [searchQuery, dispatch]);
+
   const overlay = theme.palette.mode === 'dark' ? 'rgba(16, 16, 16, 0.01)' : 'rgba(192, 192, 192, 0.01)';
   const background = `linear-gradient(135deg, ${overlay} 0%, ${theme.palette.background.paper} 100%)`;
 
@@ -107,6 +128,15 @@ const FileTree: React.FC<FileTreeComponentProps> = ({ onFileSelect, isOpen, onTo
           searchQuery={searchQuery}
           onSearchChange={handleSearchChange}
           onClearSearch={handleClearSearch}
+        />
+      )}
+      {(isMobile || isOpen) && (
+        <ContentSearchResults
+          searchQuery={searchQuery}
+          results={contentSearchResults}
+          loading={contentSearchLoading}
+          error={contentSearchError}
+          onFileSelect={isMobile ? handleFileSelectWithClose : onFileSelect}
         />
       )}
       {(isMobile || isOpen) && (

--- a/packages/frontend/src/components/LeftPane/FileTreeSearch.tsx
+++ b/packages/frontend/src/components/LeftPane/FileTreeSearch.tsx
@@ -12,7 +12,7 @@ const FileTreeSearch: React.FC<FileTreeSearchProps> = ({ searchQuery, onSearchCh
   return (
     <Box mb={2} px={2}>
       <InputBase
-        placeholder="Search files..."
+        placeholder="Search files and content..."
         inputProps={{ 'aria-label': 'search files' }}
         sx={{
           flex: 1,

--- a/packages/frontend/src/store/slices/fileTreeSlice.ts
+++ b/packages/frontend/src/store/slices/fileTreeSlice.ts
@@ -6,10 +6,19 @@ export interface FileTreeItem {
   status: string;
 }
 
+export interface ContentSearchResult {
+  path: string;
+  line: number;
+  preview: string;
+}
+
 export interface FileTreeState {
   fileTree: (FileTreeItem | { [key: string]: (FileTreeItem | object)[] })[];
   filteredFileTree: (FileTreeItem | { [key: string]: (FileTreeItem | object)[] })[];
   searchQuery: string;
+  contentSearchResults: ContentSearchResult[];
+  contentSearchLoading: boolean;
+  contentSearchError: string | null;
   expandedNodes: string[];
   mountedDirectoryPath: string;
   isGitRepository: boolean;
@@ -21,6 +30,9 @@ const initialState: FileTreeState = {
   fileTree: [],
   filteredFileTree: [],
   searchQuery: '',
+  contentSearchResults: [],
+  contentSearchLoading: false,
+  contentSearchError: null,
   expandedNodes: [],
   mountedDirectoryPath: '',
   isGitRepository: false,
@@ -113,6 +125,20 @@ export const fetchFileTree = createAsyncThunk(
   }
 );
 
+export const fetchContentSearchResults = createAsyncThunk(
+  'fileTree/fetchContentSearchResults',
+  async (query: string) => {
+    const trimmedQuery = query.trim();
+    if (!trimmedQuery) return [];
+
+    const data = await fetchData<{ results: ContentSearchResult[] }>(
+      `/api/search?q=${encodeURIComponent(trimmedQuery)}`,
+      'json',
+    );
+    return data?.results || [];
+  }
+);
+
 const fileTreeSlice = createSlice({
   name: 'fileTree',
   initialState,
@@ -157,6 +183,11 @@ const fileTreeSlice = createSlice({
     setMountedDirectoryPath: (state, action: { payload: string }) => {
       state.mountedDirectoryPath = action.payload;
     },
+    clearContentSearchResults: (state) => {
+      state.contentSearchResults = [];
+      state.contentSearchLoading = false;
+      state.contentSearchError = null;
+    },
   },
   extraReducers: (builder) => {
     builder
@@ -175,6 +206,20 @@ const fileTreeSlice = createSlice({
       .addCase(fetchFileTree.rejected, (state, action) => {
         state.loading = false;
         state.error = action.error.message || 'Failed to fetch file tree';
+      })
+      .addCase(fetchContentSearchResults.pending, (state) => {
+        state.contentSearchLoading = true;
+        state.contentSearchError = null;
+      })
+      .addCase(fetchContentSearchResults.fulfilled, (state, action) => {
+        state.contentSearchLoading = false;
+        if (action.meta.arg.trim() === state.searchQuery.trim()) {
+          state.contentSearchResults = action.payload;
+        }
+      })
+      .addCase(fetchContentSearchResults.rejected, (state, action) => {
+        state.contentSearchLoading = false;
+        state.contentSearchError = action.error.message || 'Failed to search content';
       });
   },
 });
@@ -249,6 +294,7 @@ export const selectFilteredFileTree = (
 };
 
 export const {
+  clearContentSearchResults,
   setSearchQuery,
   toggleNode,
   setExpandedNodes,

--- a/packages/frontend/test/unit/components/LeftPane/ContentSearchResults.test.tsx
+++ b/packages/frontend/test/unit/components/LeftPane/ContentSearchResults.test.tsx
@@ -1,0 +1,70 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import ContentSearchResults from '../../../../src/components/LeftPane/ContentSearchResults';
+
+describe('ContentSearchResults', () => {
+  const results = [
+    { path: 'docs/guide.md', line: 12, preview: 'Use mdts to preview markdown files' },
+  ];
+
+  it('does not render for short search queries', () => {
+    render(
+      <ContentSearchResults
+        searchQuery="m"
+        results={results}
+        loading={false}
+        error={null}
+        onFileSelect={jest.fn()}
+      />
+    );
+
+    expect(screen.queryByText('Content matches')).not.toBeInTheDocument();
+  });
+
+  it('renders content matches and opens the selected file', () => {
+    const onFileSelect = jest.fn();
+    render(
+      <ContentSearchResults
+        searchQuery="mdts"
+        results={results}
+        loading={false}
+        error={null}
+        onFileSelect={onFileSelect}
+      />
+    );
+
+    expect(screen.getByText('Content matches')).toBeInTheDocument();
+    expect(screen.getByText('docs/guide.md')).toBeInTheDocument();
+    expect(screen.getByText('Line 12')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('docs/guide.md'));
+    expect(onFileSelect).toHaveBeenCalledWith('docs/guide.md');
+  });
+
+  it('renders a loading indicator', () => {
+    render(
+      <ContentSearchResults
+        searchQuery="mdts"
+        results={[]}
+        loading={true}
+        error={null}
+        onFileSelect={jest.fn()}
+      />
+    );
+
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  });
+
+  it('renders an error message', () => {
+    render(
+      <ContentSearchResults
+        searchQuery="mdts"
+        results={[]}
+        loading={false}
+        error="failed"
+        onFileSelect={jest.fn()}
+      />
+    );
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Search failed');
+  });
+});

--- a/packages/frontend/test/unit/components/LeftPane/FileTree.test.tsx
+++ b/packages/frontend/test/unit/components/LeftPane/FileTree.test.tsx
@@ -4,7 +4,14 @@ import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import { thunk } from 'redux-thunk';
 import FileTree from '../../../../src/components/LeftPane/FileTree';
-import { fetchFileTree, setSearchQuery, expandAllNodes, setExpandedNodes } from '../../../../src/store/slices/fileTreeSlice';
+import {
+  clearContentSearchResults,
+  expandAllNodes,
+  fetchContentSearchResults,
+  fetchFileTree,
+  setExpandedNodes,
+  setSearchQuery,
+} from '../../../../src/store/slices/fileTreeSlice';
 
 const mockStore = configureStore([thunk]);
 
@@ -13,6 +20,8 @@ jest.mock('../../../../src/store/slices/fileTreeSlice', () => ({
   fetchFileTree: Object.assign(jest.fn(() => ({ type: 'fileTree/fetchFileTree/pending' })), {
     fulfilled: jest.fn((payload) => ({ type: 'fileTree/fetchFileTree/fulfilled', payload })),
   }),
+  fetchContentSearchResults: jest.fn((payload) => ({ type: 'fileTree/fetchContentSearchResults/pending', payload })),
+  clearContentSearchResults: jest.fn(() => ({ type: 'fileTree/clearContentSearchResults' })),
   expandAllNodes: jest.fn((payload) => ({ type: 'fileTree/expandAllNodes', payload })),
   setExpandedNodes: jest.fn((payload) => ({ type: 'fileTree/setExpandedNodes', payload })),
   setFilteredFileTree: jest.fn((payload) => ({ type: 'fileTree/setFilteredFileTree', payload }))
@@ -33,6 +42,9 @@ describe('FileTree', () => {
       loading: false,
       error: null,
       searchQuery: '',
+      contentSearchResults: [],
+      contentSearchLoading: false,
+      contentSearchError: null,
       expandedNodes: [],
       mountedDirectoryPath: '',
     },
@@ -68,7 +80,7 @@ describe('FileTree', () => {
       </Provider>
     );
 
-    const searchInput = screen.getByPlaceholderText('Search files...');
+    const searchInput = screen.getByPlaceholderText('Search files and content...');
     fireEvent.change(searchInput, { target: { value: 'file' } });
 
     expect(store.dispatch).toHaveBeenCalledWith(setSearchQuery('file'));
@@ -94,6 +106,31 @@ describe('FileTree', () => {
     fireEvent.click(clearButton);
 
     expect(store.dispatch).toHaveBeenCalledWith(setSearchQuery(''));
+    expect(store.dispatch).toHaveBeenCalledWith(clearContentSearchResults());
+  });
+
+  test('dispatches content search after search query debounce', async () => {
+    jest.useFakeTimers();
+    store = mockStore({
+      fileTree: {
+        ...initialState.fileTree,
+        searchQuery: 'markdown',
+      },
+    });
+    jest.spyOn(store, 'dispatch');
+
+    render(
+      <Provider store={store}>
+        <FileTree onFileSelect={jest.fn()} isOpen={true} onToggle={jest.fn()} selectedFilePath={null} />
+      </Provider>
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(250);
+    });
+
+    expect(store.dispatch).toHaveBeenCalledWith(fetchContentSearchResults('markdown'));
+    jest.useRealTimers();
   });
 
   test('dispatches expandAllNodes when expand all button is clicked', () => {

--- a/packages/frontend/test/unit/components/LeftPane/FileTreeSearch.test.tsx
+++ b/packages/frontend/test/unit/components/LeftPane/FileTreeSearch.test.tsx
@@ -8,7 +8,7 @@ describe('FileTreeSearch', () => {
       <FileTreeSearch searchQuery="" onSearchChange={jest.fn()} onClearSearch={jest.fn()} />
     );
     expect(asFragment()).toMatchSnapshot();
-    expect(screen.getByPlaceholderText('Search files...')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Search files and content...')).toBeInTheDocument();
     expect(screen.queryByLabelText('clear search')).not.toBeInTheDocument();
   });
 
@@ -26,7 +26,7 @@ describe('FileTreeSearch', () => {
     render(
       <FileTreeSearch searchQuery="" onSearchChange={onSearchChangeMock} onClearSearch={jest.fn()} />
     );
-    fireEvent.change(screen.getByPlaceholderText('Search files...'), { target: { value: 'new query' } });
+    fireEvent.change(screen.getByPlaceholderText('Search files and content...'), { target: { value: 'new query' } });
     expect(onSearchChangeMock).toHaveBeenCalledWith(expect.any(Object));
   });
 

--- a/packages/frontend/test/unit/components/LeftPane/__snapshots__/FileTree.test.tsx.snap
+++ b/packages/frontend/test/unit/components/LeftPane/__snapshots__/FileTree.test.tsx.snap
@@ -83,7 +83,7 @@ exports[`FileTree renders correctly 1`] = `
         <input
           aria-label="search files"
           class="MuiInputBase-input css-e77w8q-MuiInputBase-input"
-          placeholder="Search files..."
+          placeholder="Search files and content..."
           type="text"
           value=""
         />

--- a/packages/frontend/test/unit/components/LeftPane/__snapshots__/FileTreeSearch.test.tsx.snap
+++ b/packages/frontend/test/unit/components/LeftPane/__snapshots__/FileTreeSearch.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`FileTreeSearch renders correctly with a search query 1`] = `
       <input
         aria-label="search files"
         class="MuiInputBase-input css-e77w8q-MuiInputBase-input"
-        placeholder="Search files..."
+        placeholder="Search files and content..."
         type="text"
         value="test"
       />
@@ -57,7 +57,7 @@ exports[`FileTreeSearch renders correctly with empty search query 1`] = `
       <input
         aria-label="search files"
         class="MuiInputBase-input css-e77w8q-MuiInputBase-input"
-        placeholder="Search files..."
+        placeholder="Search files and content..."
         type="text"
         value=""
       />

--- a/packages/frontend/test/unit/store/fileTreeSlice.test.ts
+++ b/packages/frontend/test/unit/store/fileTreeSlice.test.ts
@@ -1,6 +1,8 @@
 import { configureStore } from '@reduxjs/toolkit';
 import fileTreeReducer, {
+  clearContentSearchResults,
   expandAllNodes,
+  fetchContentSearchResults,
   fetchFileTree,
   selectFilteredFileTree,
   setExpandedNodes,
@@ -44,6 +46,9 @@ describe('fileTreeSlice', () => {
     expect(store.getState().fileTree.fileTree).toEqual([]);
     expect(store.getState().fileTree.filteredFileTree).toEqual([]);
     expect(store.getState().fileTree.searchQuery).toEqual('');
+    expect(store.getState().fileTree.contentSearchResults).toEqual([]);
+    expect(store.getState().fileTree.contentSearchLoading).toBe(false);
+    expect(store.getState().fileTree.contentSearchError).toBeNull();
     expect(store.getState().fileTree.expandedNodes).toEqual([]);
     expect(store.getState().fileTree.mountedDirectoryPath).toEqual('');
     expect(store.getState().fileTree.loading).toBe(true);
@@ -147,6 +152,19 @@ describe('fileTreeSlice', () => {
     expect(store.getState().fileTree.mountedDirectoryPath).toEqual('/new/path');
   });
 
+  it('should handle clearContentSearchResults', () => {
+    store.dispatch(fetchContentSearchResults.pending('requestId', 'mdts'));
+    store.dispatch(fetchContentSearchResults.fulfilled([
+      { path: 'README.md', line: 1, preview: 'mdts' },
+    ], 'requestId', 'mdts'));
+
+    store.dispatch(clearContentSearchResults());
+
+    expect(store.getState().fileTree.contentSearchResults).toEqual([]);
+    expect(store.getState().fileTree.contentSearchLoading).toBe(false);
+    expect(store.getState().fileTree.contentSearchError).toBeNull();
+  });
+
   it('should remove the oldest expanded node cache when recent paths exceed the limit', () => {
     const paths = Array.from({ length: 11 }, (_, index) => `/test/path-${index + 1}`);
 
@@ -226,6 +244,58 @@ describe('fileTreeSlice', () => {
 
       expect(store.getState().fileTree.loading).toBe(false);
       expect(store.getState().fileTree.error).toEqual(errorMessage);
+    });
+  });
+
+  describe('fetchContentSearchResults async thunk', () => {
+    it('should call the search API with the encoded query', async () => {
+      const results = [{ path: 'README.md', line: 2, preview: 'hello world' }];
+      (fetchData as jest.Mock).mockResolvedValueOnce({ results });
+
+      await store.dispatch(fetchContentSearchResults('hello world'));
+
+      expect(fetchData).toHaveBeenCalledWith('/api/search?q=hello%20world', 'json');
+    });
+
+    it('should not call the API for blank queries', async () => {
+      await store.dispatch(fetchContentSearchResults('   '));
+
+      expect(fetchData).not.toHaveBeenCalled();
+    });
+
+    it('should store results for the current search query', () => {
+      store.dispatch(setSearchQuery('mdts'));
+      store.dispatch(fetchContentSearchResults.pending('requestId', 'mdts'));
+      expect(store.getState().fileTree.contentSearchLoading).toBe(true);
+
+      store.dispatch(fetchContentSearchResults.fulfilled([
+        { path: 'README.md', line: 1, preview: 'mdts' },
+      ], 'requestId', 'mdts'));
+
+      expect(store.getState().fileTree.contentSearchLoading).toBe(false);
+      expect(store.getState().fileTree.contentSearchResults).toEqual([
+        { path: 'README.md', line: 1, preview: 'mdts' },
+      ]);
+    });
+
+    it('should ignore stale search results', () => {
+      store.dispatch(setSearchQuery('current'));
+      store.dispatch(fetchContentSearchResults.fulfilled([
+        { path: 'old.md', line: 1, preview: 'old' },
+      ], 'requestId', 'old'));
+
+      expect(store.getState().fileTree.contentSearchResults).toEqual([]);
+    });
+
+    it('should handle rejected content search state', () => {
+      store.dispatch(fetchContentSearchResults.rejected(
+        new Error('Search failed'),
+        'requestId',
+        'mdts',
+      ));
+
+      expect(store.getState().fileTree.contentSearchLoading).toBe(false);
+      expect(store.getState().fileTree.contentSearchError).toEqual('Search failed');
     });
   });
 

--- a/packages/frontend/test/utils.ts
+++ b/packages/frontend/test/utils.ts
@@ -27,6 +27,9 @@ export const createMockStore = (
       loading: false,
       error: null,
       searchQuery: '',
+      contentSearchResults: [],
+      contentSearchLoading: false,
+      contentSearchError: null,
       isGitRepository: true,
     },
     content: {

--- a/src/server/routes/search.ts
+++ b/src/server/routes/search.ts
@@ -1,0 +1,122 @@
+import { Router } from 'express';
+import fs, { Dirent } from 'fs';
+import path from 'path';
+import { EXCLUDED_DIRECTORIES } from '../../constants';
+import { resolveGlobPatterns } from '../../utils/glob';
+import { ServerContext } from '../context';
+
+type SearchResult = {
+  path: string;
+  line: number;
+  preview: string;
+};
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 100;
+const MAX_PREVIEW_LENGTH = 240;
+
+const toPosixPath = (filePath: string): string => filePath.replace(/\\/g, '/').split(path.sep).join('/');
+
+const isMarkdownFile = (filePath: string): boolean => {
+  const lowerPath = filePath.toLowerCase();
+  return lowerPath.endsWith('.md') || lowerPath.endsWith('.markdown');
+};
+
+const shouldIncludeEntry = (entry: Dirent): boolean => {
+  return !entry.name.startsWith('.') && !EXCLUDED_DIRECTORIES.includes(entry.name);
+};
+
+const collectMarkdownFiles = (baseDirectory: string, currentRelativePath: string = ''): string[] => {
+  const fullPath = path.join(baseDirectory, currentRelativePath);
+  let entries: Dirent[];
+
+  try {
+    entries = fs.readdirSync(fullPath, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  return entries.filter(shouldIncludeEntry).flatMap(entry => {
+    const entryPath = path.join(currentRelativePath, entry.name);
+    if (entry.isDirectory()) {
+      return collectMarkdownFiles(baseDirectory, entryPath);
+    }
+    return isMarkdownFile(entry.name) ? [toPosixPath(entryPath)] : [];
+  });
+};
+
+const getSearchableFiles = (context: ServerContext): string[] => {
+  if (context.filePatterns) {
+    return context.filePatterns.filter(isMarkdownFile).map(toPosixPath).sort();
+  }
+
+  if (context.globPatterns) {
+    return (resolveGlobPatterns(context.directory, context.globPatterns).filePatterns || [])
+      .filter(isMarkdownFile)
+      .map(toPosixPath)
+      .sort();
+  }
+
+  return collectMarkdownFiles(context.directory).sort();
+};
+
+const parseLimit = (value: unknown): number => {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1) return DEFAULT_LIMIT;
+  return Math.min(parsed, MAX_LIMIT);
+};
+
+const findMatchesInFile = (
+  directory: string,
+  filePath: string,
+  query: string,
+  remainingLimit: number,
+): SearchResult[] => {
+  let content: string;
+
+  try {
+    content = fs.readFileSync(path.join(directory, filePath), 'utf8');
+  } catch {
+    return [];
+  }
+
+  const lowerQuery = query.toLowerCase();
+  const matches: SearchResult[] = [];
+
+  content.split(/\r?\n/).some((line, index) => {
+    if (line.toLowerCase().includes(lowerQuery)) {
+      matches.push({
+        path: filePath,
+        line: index + 1,
+        preview: line.trim().slice(0, MAX_PREVIEW_LENGTH),
+      });
+    }
+    return matches.length >= remainingLimit;
+  });
+
+  return matches;
+};
+
+export const searchRouter = (context: ServerContext): Router => {
+  const router = Router();
+
+  router.get('/', (req, res) => {
+    const query = typeof req.query.q === 'string' ? req.query.q.trim() : '';
+    if (!query) {
+      return res.json({ results: [] });
+    }
+
+    const limit = parseLimit(req.query.limit);
+    const results: SearchResult[] = [];
+
+    for (const filePath of getSearchableFiles(context)) {
+      const remainingLimit = limit - results.length;
+      if (remainingLimit <= 0) break;
+      results.push(...findMatchesInFile(context.directory, filePath, query, remainingLimit));
+    }
+
+    res.json({ results });
+  });
+
+  return router;
+};

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -9,6 +9,7 @@ import { getConfig, saveConfig } from './config';
 import { setupWatcher } from './watcher';
 import { diffRouter, diffPrevRouter } from './routes/diff';
 import { plantumlRouter } from './routes/plantuml';
+import { searchRouter } from './routes/search';
 
 const MAX_PORT_RETRIES = 10;
 
@@ -72,6 +73,7 @@ export const createApp = (
   app.use('/api/diff-prev', diffPrevRouter(context));
   app.use('/api/diff', diffRouter(context));
   app.use('/api/plantuml', plantumlRouter());
+  app.use('/api/search', searchRouter(context));
   app.get('/api/config', (req, res) => {
     res.json(getConfig());
   });
@@ -148,4 +150,3 @@ export const createApp = (
 
   return app;
 };
-

--- a/test/unit/server/routes/search.test.ts
+++ b/test/unit/server/routes/search.test.ts
@@ -1,0 +1,121 @@
+import express from 'express';
+import fs from 'fs';
+import path from 'path';
+import request from 'supertest';
+import { searchRouter } from '../../../../src/server/routes/search';
+
+jest.mock('fs', () => ({
+  ...jest.requireActual('fs'),
+  readdirSync: jest.fn(),
+  readFileSync: jest.fn(),
+}));
+
+jest.mock('glob', () => ({
+  globSync: jest.fn(() => []),
+}));
+
+const mockDirent = (name: string, isDirectory: boolean) => ({
+  name,
+  isDirectory: () => isDirectory,
+  isFile: () => !isDirectory,
+});
+
+describe('searchRouter', () => {
+  const mockDirectory = path.resolve('D:/mock/base/dir');
+  let app: express.Application;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    app = express();
+    app.use('/api/search', searchRouter({ directory: mockDirectory }));
+  });
+
+  it('should return no results for an empty query', async () => {
+    const response = await request(app).get('/api/search?q=');
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toEqual({ results: [] });
+    expect(fs.readdirSync).not.toHaveBeenCalled();
+  });
+
+  it('should search markdown files recursively', async () => {
+    (fs.readdirSync as jest.Mock)
+      .mockReturnValueOnce([
+        mockDirent('docs', true),
+        mockDirent('README.md', false),
+        mockDirent('notes.txt', false),
+        mockDirent('node_modules', true),
+        mockDirent('.hidden', true),
+      ])
+      .mockReturnValueOnce([
+        mockDirent('guide.markdown', false),
+      ]);
+
+    (fs.readFileSync as jest.Mock).mockImplementation((filePath: string) => {
+      if (filePath.endsWith('README.md')) return 'Intro\nInstall mdts quickly';
+      if (filePath.endsWith('guide.markdown')) return 'Usage\nMDTS supports live preview';
+      return '';
+    });
+
+    const response = await request(app).get('/api/search?q=mdts');
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toEqual({
+      results: [
+        { path: 'README.md', line: 2, preview: 'Install mdts quickly' },
+        { path: 'docs/guide.markdown', line: 2, preview: 'MDTS supports live preview' },
+      ],
+    });
+    expect(fs.readFileSync).toHaveBeenCalledTimes(2);
+  });
+
+  it('should honor the result limit', async () => {
+    (fs.readdirSync as jest.Mock).mockReturnValueOnce([
+      mockDirent('a.md', false),
+      mockDirent('b.md', false),
+    ]);
+    (fs.readFileSync as jest.Mock).mockReturnValue('target\ntarget again');
+
+    const response = await request(app).get('/api/search?q=target&limit=2');
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body.results).toHaveLength(2);
+    expect(response.body.results).toEqual([
+      { path: 'a.md', line: 1, preview: 'target' },
+      { path: 'a.md', line: 2, preview: 'target again' },
+    ]);
+  });
+
+  it('should use file patterns when provided', async () => {
+    app = express();
+    app.use('/api/search', searchRouter({
+      directory: mockDirectory,
+      filePatterns: ['docs\\guide.md', 'docs\\skip.txt'],
+    }));
+    (fs.readFileSync as jest.Mock).mockReturnValue('find this line');
+
+    const response = await request(app).get('/api/search?q=find');
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toEqual({
+      results: [
+        { path: 'docs/guide.md', line: 1, preview: 'find this line' },
+      ],
+    });
+    expect(fs.readdirSync).not.toHaveBeenCalled();
+  });
+
+  it('should skip unreadable files', async () => {
+    (fs.readdirSync as jest.Mock).mockReturnValueOnce([
+      mockDirent('README.md', false),
+    ]);
+    (fs.readFileSync as jest.Mock).mockImplementation(() => {
+      throw new Error('cannot read');
+    });
+
+    const response = await request(app).get('/api/search?q=readme');
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toEqual({ results: [] });
+  });
+});


### PR DESCRIPTION
## Summary

- Add an `/api/search` endpoint for full text search across markdown files
- Respect mounted file patterns and excluded directories while searching
- Show content search matches below the existing left-pane search box
- Add route, store, component, and interaction coverage

Closes #79

## Verification

- Ran `git diff --check`
- Ran targeted ESLint for the new server route, frontend components, store slice, and related tests
- Ran root `tsc -p tsconfig.json --noEmit`
- Ran focused Jest coverage for `search.test.ts`: 1 suite / 5 tests passed
- Ran focused frontend Jest coverage: 4 suites / 48 tests passed
- Ran frontend webpack build directly through `webpack-cli/bin/cli.js`