### PR TITLE
feat: add markdown export options

### DIFF
--- a/packages/frontend/src/components/Content/MarkdownContent/MarkdownContent.tsx
+++ b/packages/frontend/src/components/Content/MarkdownContent/MarkdownContent.tsx
@@ -1,5 +1,5 @@
-import { ArticleOutlined } from '@mui/icons-material';
-import { Box, Chip, Typography } from '@mui/material';
+import { ArticleOutlined, DownloadOutlined, PrintOutlined } from '@mui/icons-material';
+import { Box, Chip, IconButton, Tooltip, Typography } from '@mui/material';
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useFrontmatter } from '../../../hooks/useFrontmatter';
@@ -66,6 +66,12 @@ const MarkdownContent: React.FC<MarkdownContentProps> = ({ scrollToId, onDirecto
         : '🎉 Welcome to mdts!';
 
   const hasFrontmatter = Object.keys(frontmatter).length > 0;
+  const exportHtmlUrl = currentPath
+    ? `/api/export/html?filePath=${encodeURIComponent(currentPath)}`
+    : null;
+  const printUrl = currentPath
+    ? `/api/export/print?filePath=${encodeURIComponent(currentPath)}`
+    : null;
 
   if (error) {
     return <ErrorView error={error} />;
@@ -95,6 +101,33 @@ const MarkdownContent: React.FC<MarkdownContentProps> = ({ scrollToId, onDirecto
         <Typography variant={isMobile ? 'h5' : 'h4'} gutterBottom sx={{ mb: 0, wordBreak: 'break-word' }}>
           {displayFileName}
         </Typography>
+        {exportHtmlUrl && (
+          <Tooltip title="Export as HTML">
+            <IconButton
+              aria-label="export as html"
+              component="a"
+              href={exportHtmlUrl}
+              size={isMobile ? 'small' : 'medium'}
+              sx={{ ml: 1 }}
+            >
+              <DownloadOutlined />
+            </IconButton>
+          </Tooltip>
+        )}
+        {printUrl && (
+          <Tooltip title="Print or save as PDF">
+            <IconButton
+              aria-label="print or save as pdf"
+              component="a"
+              href={printUrl}
+              rel="noopener noreferrer"
+              target="_blank"
+              size={isMobile ? 'small' : 'medium'}
+            >
+              <PrintOutlined />
+            </IconButton>
+          </Tooltip>
+        )}
       </Box>
       {frontmatter.tags && Array.isArray(frontmatter.tags) && frontmatter.tags.length > 0 && (
         <Box sx={{ display: 'flex', gap: 1, mb: 2 }}>

--- a/packages/frontend/test/unit/components/Content/MarkdownContent/MarkdownContent.test.tsx
+++ b/packages/frontend/test/unit/components/Content/MarkdownContent/MarkdownContent.test.tsx
@@ -145,6 +145,15 @@ describe('MarkdownContent', () => {
       );
     });
 
+    expect(screen.getByLabelText('export as html')).toHaveAttribute(
+      'href',
+      '/api/export/html?filePath=%2Fpath%2Fto%2Ftest.md',
+    );
+    expect(screen.getByLabelText('print or save as pdf')).toHaveAttribute(
+      'href',
+      '/api/export/print?filePath=%2Fpath%2Fto%2Ftest.md',
+    );
+    expect(screen.getByLabelText('print or save as pdf')).toHaveAttribute('target', '_blank');
     fireEvent.click(screen.getByRole('tab', { name: /raw/i }));
     expect(screen.getByTestId('mock-react-markdown')).toBeInTheDocument();
   });

--- a/src/server/routes/export.ts
+++ b/src/server/routes/export.ts
@@ -1,0 +1,149 @@
+import { Router } from 'express';
+import fs from 'fs';
+import MarkdownIt from 'markdown-it';
+import path from 'path';
+import { ServerContext } from '../context';
+
+const md = new MarkdownIt({
+  html: true,
+  linkify: true,
+  typographer: true,
+});
+
+const isInsideDirectory = (baseDirectory: string, targetPath: string): boolean => {
+  const relativePath = path.relative(baseDirectory, targetPath);
+  return relativePath === '' || (!relativePath.startsWith('..') && !path.isAbsolute(relativePath));
+};
+
+const isMarkdownFile = (filePath: string): boolean => {
+  const lowerPath = filePath.toLowerCase();
+  return lowerPath.endsWith('.md') || lowerPath.endsWith('.markdown');
+};
+
+const escapeHtml = (value: string): string => {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+};
+
+const toHtmlFileName = (filePath: string): string => {
+  const fileName = path.basename(filePath).replace(/\.(md|markdown)$/i, '.html');
+  return fileName === path.basename(filePath) ? `${fileName}.html` : fileName;
+};
+
+interface HtmlDocumentOptions {
+  autoPrint?: boolean;
+}
+
+const buildHtmlDocument = (filePath: string, markdown: string, options: HtmlDocumentOptions = {}): string => {
+  const title = path.basename(filePath);
+  const renderedMarkdown = md.render(markdown);
+  const printScript = options.autoPrint
+    ? [
+      '  <script>',
+      '    window.addEventListener("load", () => window.print());',
+      '  </script>',
+    ]
+    : [];
+
+  return [
+    '<!doctype html>',
+    '<html>',
+    '<head>',
+    '  <meta charset="utf-8">',
+    '  <meta name="viewport" content="width=device-width, initial-scale=1">',
+    `  <title>${escapeHtml(title)}</title>`,
+    '  <style>',
+    '    body { box-sizing: border-box; max-width: 900px; margin: 40px auto; padding: 0 24px;',
+    '      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;',
+    '      line-height: 1.65; color: #24292f; }',
+    '    pre { overflow: auto; padding: 16px; background: #f6f8fa; border-radius: 6px; }',
+    '    code { font-family: ui-monospace, SFMono-Regular, "SF Mono", Consolas, monospace; }',
+    '    table { border-collapse: collapse; width: 100%; display: block; overflow: auto; }',
+    '    th, td { border: 1px solid #d0d7de; padding: 6px 13px; }',
+    '    blockquote { margin-left: 0; padding-left: 16px; color: #57606a; border-left: 4px solid #d0d7de; }',
+    '    img { max-width: 100%; }',
+    '  </style>',
+    ...printScript,
+    '</head>',
+    '<body>',
+    renderedMarkdown,
+    '</body>',
+    '</html>',
+  ].join('\n');
+};
+
+interface LoadedMarkdown {
+  filePath: string;
+  markdown: string;
+}
+
+interface ExportError {
+  error: string;
+  statusCode: number;
+}
+
+const loadMarkdown = (directory: string, filePath: string): LoadedMarkdown | ExportError => {
+  if (!filePath.trim()) {
+    return { statusCode: 400, error: 'filePath is required' };
+  }
+
+  if (!isMarkdownFile(filePath)) {
+    return { statusCode: 400, error: 'Only markdown files can be exported' };
+  }
+
+  const absoluteFilePath = path.resolve(directory, filePath);
+  if (!isInsideDirectory(directory, absoluteFilePath)) {
+    return { statusCode: 403, error: 'Forbidden' };
+  }
+
+  if (!fs.existsSync(absoluteFilePath)) {
+    return { statusCode: 404, error: 'File not found' };
+  }
+
+  if (fs.statSync(absoluteFilePath).isDirectory()) {
+    return { statusCode: 400, error: 'Cannot export a directory' };
+  }
+
+  return {
+    filePath,
+    markdown: fs.readFileSync(absoluteFilePath, 'utf8'),
+  };
+};
+
+const isExportError = (result: LoadedMarkdown | ExportError): result is ExportError => {
+  return 'error' in result;
+};
+
+export const exportRouter = (context: ServerContext): Router => {
+  const router = Router();
+  const { directory } = context;
+
+  router.get('/html', (req, res) => {
+    const filePath = typeof req.query.filePath === 'string' ? req.query.filePath : '';
+    const result = loadMarkdown(directory, filePath);
+    if (isExportError(result)) {
+      return res.status(result.statusCode).json({ error: result.error });
+    }
+
+    const html = buildHtmlDocument(result.filePath, result.markdown);
+    res.attachment(toHtmlFileName(filePath));
+    res.type('html').send(html);
+  });
+
+  router.get('/print', (req, res) => {
+    const filePath = typeof req.query.filePath === 'string' ? req.query.filePath : '';
+    const result = loadMarkdown(directory, filePath);
+    if (isExportError(result)) {
+      return res.status(result.statusCode).json({ error: result.error });
+    }
+
+    const html = buildHtmlDocument(result.filePath, result.markdown, { autoPrint: true });
+    res.type('html').send(html);
+  });
+
+  return router;
+};

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -8,6 +8,7 @@ import { outlineRouter } from './routes/outline';
 import { getConfig, saveConfig } from './config';
 import { setupWatcher } from './watcher';
 import { diffRouter, diffPrevRouter } from './routes/diff';
+import { exportRouter } from './routes/export';
 import { plantumlRouter } from './routes/plantuml';
 
 const MAX_PORT_RETRIES = 10;
@@ -71,6 +72,7 @@ export const createApp = (
   app.use('/api/outline', outlineRouter(directory));
   app.use('/api/diff-prev', diffPrevRouter(context));
   app.use('/api/diff', diffRouter(context));
+  app.use('/api/export', exportRouter(context));
   app.use('/api/plantuml', plantumlRouter());
   app.get('/api/config', (req, res) => {
     res.json(getConfig());
@@ -148,4 +150,3 @@ export const createApp = (
 
   return app;
 };
-

--- a/test/unit/server/routes/export.test.ts
+++ b/test/unit/server/routes/export.test.ts
@@ -1,0 +1,89 @@
+import express from 'express';
+import fs from 'fs';
+import path from 'path';
+import request from 'supertest';
+import { exportRouter } from '../../../../src/server/routes/export';
+
+jest.mock('fs', () => ({
+  ...jest.requireActual('fs'),
+  existsSync: jest.fn(),
+  readFileSync: jest.fn(),
+  statSync: jest.fn(),
+}));
+
+describe('exportRouter', () => {
+  const mockDirectory = path.resolve('D:/mock/base/dir');
+  let app: express.Application;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (fs.existsSync as jest.Mock).mockReturnValue(true);
+    (fs.statSync as jest.Mock).mockReturnValue({ isDirectory: () => false });
+    (fs.readFileSync as jest.Mock).mockReturnValue('# Hello\n\nExport this markdown.');
+
+    app = express();
+    app.use('/api/export', exportRouter({ directory: mockDirectory }));
+  });
+
+  it('should require filePath', async () => {
+    const response = await request(app).get('/api/export/html');
+
+    expect(response.statusCode).toBe(400);
+    expect(response.body).toEqual({ error: 'filePath is required' });
+  });
+
+  it('should only export markdown files', async () => {
+    const response = await request(app).get('/api/export/html?filePath=notes.txt');
+
+    expect(response.statusCode).toBe(400);
+    expect(response.body).toEqual({ error: 'Only markdown files can be exported' });
+  });
+
+  it('should prevent path traversal', async () => {
+    const response = await request(app).get('/api/export/html?filePath=../secret.md');
+
+    expect(response.statusCode).toBe(403);
+    expect(response.body).toEqual({ error: 'Forbidden' });
+  });
+
+  it('should return 404 for missing files', async () => {
+    (fs.existsSync as jest.Mock).mockReturnValue(false);
+
+    const response = await request(app).get('/api/export/html?filePath=missing.md');
+
+    expect(response.statusCode).toBe(404);
+    expect(response.body).toEqual({ error: 'File not found' });
+  });
+
+  it('should reject directories', async () => {
+    (fs.statSync as jest.Mock).mockReturnValue({ isDirectory: () => true });
+
+    const response = await request(app).get('/api/export/html?filePath=docs.md');
+
+    expect(response.statusCode).toBe(400);
+    expect(response.body).toEqual({ error: 'Cannot export a directory' });
+  });
+
+  it('should export markdown as an HTML attachment', async () => {
+    const response = await request(app).get('/api/export/html?filePath=docs/guide.md');
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['content-type']).toContain('text/html');
+    expect(response.headers['content-disposition']).toContain('attachment; filename="guide.html"');
+    expect(response.text).toContain('<!doctype html>');
+    expect(response.text).toContain('<h1>Hello</h1>');
+    expect(response.text).toContain('<p>Export this markdown.</p>');
+    expect(fs.readFileSync).toHaveBeenCalledWith(path.resolve(mockDirectory, 'docs/guide.md'), 'utf8');
+  });
+
+  it('should serve printable HTML for browser PDF export', async () => {
+    const response = await request(app).get('/api/export/print?filePath=docs/guide.md');
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['content-type']).toContain('text/html');
+    expect(response.headers['content-disposition']).toBeUndefined();
+    expect(response.text).toContain('<h1>Hello</h1>');
+    expect(response.text).toContain('window.print()');
+    expect(fs.readFileSync).toHaveBeenCalledWith(path.resolve(mockDirectory, 'docs/guide.md'), 'utf8');
+  });
+});


### PR DESCRIPTION
## Summary

- Add an `/api/export/html` endpoint for exporting markdown files as standalone HTML
- Add an `/api/export/print` endpoint that opens a print-ready page for browser PDF export
- Validate file paths stay inside the mounted directory before reading content
- Add export and print/save-as-PDF buttons to the markdown content header
- Cover export success, print output, and error cases with focused route tests

Related to #85

## Verification

- Ran `git diff --check`
- Ran targeted ESLint for the export route, server wiring, route test, markdown content component, and markdown content test
- Ran root `tsc -p tsconfig.json --noEmit`
- Ran focused Jest coverage for `export.test.ts`: 1 suite / 7 tests passed
- Ran focused frontend ESLint for `MarkdownContent.tsx` and `MarkdownContent.test.tsx`
- Ran frontend webpack build directly through `webpack-cli/bin/cli.js`
- Focused frontend Jest for `MarkdownContent.test.tsx` timed out locally during Jest startup on Windows; no assertion failure was emitted