### PR TITLE
chore(deps): Bump @mui/material in /packages/frontend from 9.0.1 to 9.1.1

### DIFF
--- a/packages/frontend/package-lock.json
+++ b/packages/frontend/package-lock.json
@@ -12,7 +12,7 @@
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.5",
         "@mui/icons-material": "^9.1.1",
-        "@mui/material": "^9.0.1",
+        "@mui/material": "^9.1.1",
         "@mui/x-tree-view": "^9.4.0",
         "@reduxjs/toolkit": "^2.12.0",
         "buffer": "^6.0.3",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -19,7 +19,7 @@
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",
     "@mui/icons-material": "^9.1.1",
-    "@mui/material": "^9.0.1",
+    "@mui/material": "^9.1.1",
     "@mui/x-tree-view": "^9.4.0",
     "@reduxjs/toolkit": "^2.12.0",
     "buffer": "^6.0.3",


### PR DESCRIPTION
Replaces #782. Bumps @mui/material to 9.1.1 (same as icons-material from #781). Clean branch from main with webpack ESM fix already included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated UI library dependencies to include latest bug fixes and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->