### PR TITLE
feat: auto-focus current file in the left file tree

### DIFF
--- a/packages/frontend/src/components/LeftPane/FileTree.tsx
+++ b/packages/frontend/src/components/LeftPane/FileTree.tsx
@@ -3,9 +3,11 @@ import React, { useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import useIsMobile from '../../hooks/useIsMobile';
 import {
+  ensureExpandedNodes,
   expandAllNodes,
   fetchFileTree,
   FileTreeItem,
+  getAncestorPaths,
   setExpandedNodes,
   setSearchQuery
 } from '../../store/slices/fileTreeSlice';
@@ -21,7 +23,12 @@ interface FileTreeComponentProps {
   selectedFilePath: string | null;
 }
 
-const FileTree: React.FC<FileTreeComponentProps> = ({ onFileSelect, isOpen, onToggle }) => {
+const FileTree: React.FC<FileTreeComponentProps> = ({
+  onFileSelect,
+  isOpen,
+  onToggle,
+  selectedFilePath,
+}) => {
   const dispatch = useDispatch<AppDispatch>();
   const theme = useTheme();
   const isMobile = useIsMobile();
@@ -37,6 +44,16 @@ const FileTree: React.FC<FileTreeComponentProps> = ({ onFileSelect, isOpen, onTo
   useEffect(() => {
     dispatch(fetchFileTree());
   }, [dispatch]);
+
+  // Reveal the current document in the tree: expand ancestors when path changes or tree finishes loading.
+  useEffect(() => {
+    if (!selectedFilePath || loading) return;
+
+    const ancestors = getAncestorPaths(selectedFilePath);
+    if (ancestors.length > 0) {
+      dispatch(ensureExpandedNodes(ancestors));
+    }
+  }, [selectedFilePath, loading, dispatch]);
 
   const handleSearchChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
     dispatch(setSearchQuery(event.target.value));
@@ -115,9 +132,9 @@ const FileTree: React.FC<FileTreeComponentProps> = ({ onFileSelect, isOpen, onTo
           loading={loading}
           error={error}
           expandedNodes={expandedNodes}
+          selectedFilePath={selectedFilePath}
           onFileSelect={isMobile ? handleFileSelectWithClose : onFileSelect}
           onExpandedItemsChange={handleExpandedItemsChange}
-          dispatch={dispatch}
         />
       )}
     </>

--- a/packages/frontend/src/components/LeftPane/FileTreeContent/FileTreeContent.tsx
+++ b/packages/frontend/src/components/LeftPane/FileTreeContent/FileTreeContent.tsx
@@ -10,6 +10,7 @@ interface FileTreeContentProps {
   loading: boolean;
   error: string | null;
   expandedNodes: string[];
+  selectedFilePath: string | null;
   onFileSelect: (path: string) => void;
   onExpandedItemsChange: (event: React.SyntheticEvent, itemIds: string[]) => void;
 }
@@ -19,6 +20,7 @@ const FileTreeContent: React.FC<FileTreeContentProps> = ({
   loading,
   error,
   expandedNodes,
+  selectedFilePath,
   onFileSelect,
   onExpandedItemsChange,
 }) => {
@@ -43,6 +45,7 @@ const FileTreeContent: React.FC<FileTreeContentProps> = ({
     <FileTreeView
       filteredFileTree={filteredFileTree}
       expandedNodes={expandedNodes}
+      selectedFilePath={selectedFilePath}
       onFileSelect={onFileSelect}
       onExpandedItemsChange={onExpandedItemsChange}
       getStatusColor={getStatusColor}

--- a/packages/frontend/src/components/LeftPane/FileTreeContent/FileTreeView.tsx
+++ b/packages/frontend/src/components/LeftPane/FileTreeContent/FileTreeView.tsx
@@ -1,13 +1,15 @@
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { SimpleTreeView } from '@mui/x-tree-view/SimpleTreeView';
-import React from 'react';
+import { useSimpleTreeViewApiRef } from '@mui/x-tree-view/hooks';
+import React, { useEffect } from 'react';
 import { RecursiveTreeItems } from './RecursiveTreeItems';
 import { FileTree } from './types';
 
 interface FileTreeViewProps {
   filteredFileTree: FileTree | null;
   expandedNodes: string[];
+  selectedFilePath: string | null;
   onFileSelect: (path: string) => void;
   onExpandedItemsChange: (event: React.SyntheticEvent, itemIds: string[]) => void;
   getStatusColor: (status: string) => string;
@@ -16,18 +18,53 @@ interface FileTreeViewProps {
 export const FileTreeView: React.FC<FileTreeViewProps> = ({
   filteredFileTree,
   expandedNodes,
+  selectedFilePath,
   onFileSelect,
   onExpandedItemsChange,
   getStatusColor
-}) => (
-  <SimpleTreeView
-    className="custom-scrollbar"
-    defaultCollapseIcon={<ExpandMoreIcon />}
-    defaultExpandIcon={<ChevronRightIcon />}
-    expandedItems={expandedNodes}
-    onExpandedItemsChange={onExpandedItemsChange}
-    sx={{ flexGrow: 1, maxWidth: 400, overflowY: 'auto', height: 'calc(100vh - 180px)', px: 2, pb: 2 }}
-  >
-    <RecursiveTreeItems tree={filteredFileTree} onFileSelect={onFileSelect} getStatusColor={getStatusColor} />
-  </SimpleTreeView>
-);
+}) => {
+  const apiRef = useSimpleTreeViewApiRef();
+
+  useEffect(() => {
+    if (!selectedFilePath) return undefined;
+
+    let cancelled = false;
+    const tryScroll = () => {
+      if (cancelled) return true;
+      const element = apiRef.current?.getItemDOMElement?.(selectedFilePath);
+      if (element) {
+        element.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+        return true;
+      }
+      return false;
+    };
+
+    if (tryScroll()) {
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    // Newly expanded parents may not have mounted the item yet.
+    const timeoutId = window.setTimeout(tryScroll, 150);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timeoutId);
+    };
+  }, [apiRef, selectedFilePath, expandedNodes]);
+
+  return (
+    <SimpleTreeView
+      apiRef={apiRef}
+      className="custom-scrollbar"
+      defaultCollapseIcon={<ExpandMoreIcon />}
+      defaultExpandIcon={<ChevronRightIcon />}
+      expandedItems={expandedNodes}
+      selectedItems={selectedFilePath}
+      onExpandedItemsChange={onExpandedItemsChange}
+      sx={{ flexGrow: 1, maxWidth: 400, overflowY: 'auto', height: 'calc(100vh - 180px)', px: 2, pb: 2 }}
+    >
+      <RecursiveTreeItems tree={filteredFileTree} onFileSelect={onFileSelect} getStatusColor={getStatusColor} />
+    </SimpleTreeView>
+  );
+};

--- a/packages/frontend/src/store/slices/fileTreeSlice.ts
+++ b/packages/frontend/src/store/slices/fileTreeSlice.ts
@@ -68,6 +68,18 @@ const loadExpandedNodes = (path: string): string[] => {
   }
 };
 
+/** Parent directory paths that must be expanded for `path` to be visible in the tree. */
+export const getAncestorPaths = (path: string): string[] => {
+  const segments = path.split('/').filter(Boolean);
+  if (segments.length <= 1) return [];
+
+  const ancestors: string[] = [];
+  for (let i = 1; i < segments.length; i += 1) {
+    ancestors.push(segments.slice(0, i).join('/'));
+  }
+  return ancestors;
+};
+
 const filterTree = (
   tree: (FileTreeItem | { [key: string]: (FileTreeItem | object)[] })[],
   searchQuery: string
@@ -132,6 +144,12 @@ const fileTreeSlice = createSlice({
     },
     setExpandedNodes: (state, action: { payload: string[] }) => {
       state.expandedNodes = action.payload;
+      saveExpandedNodes(state.mountedDirectoryPath, state.expandedNodes);
+    },
+    ensureExpandedNodes: (state, action: { payload: string[] }) => {
+      const missing = action.payload.filter((path) => !state.expandedNodes.includes(path));
+      if (missing.length === 0) return;
+      state.expandedNodes = [...state.expandedNodes, ...missing];
       saveExpandedNodes(state.mountedDirectoryPath, state.expandedNodes);
     },
     expandAllNodes: (
@@ -252,6 +270,7 @@ export const {
   setSearchQuery,
   toggleNode,
   setExpandedNodes,
+  ensureExpandedNodes,
   expandAllNodes,
   setMountedDirectoryPath,
 } = fileTreeSlice.actions;

--- a/packages/frontend/test/unit/components/LeftPane/FileTree.test.tsx
+++ b/packages/frontend/test/unit/components/LeftPane/FileTree.test.tsx
@@ -4,7 +4,13 @@ import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import { thunk } from 'redux-thunk';
 import FileTree from '../../../../src/components/LeftPane/FileTree';
-import { fetchFileTree, setSearchQuery, expandAllNodes, setExpandedNodes } from '../../../../src/store/slices/fileTreeSlice';
+import {
+  ensureExpandedNodes,
+  expandAllNodes,
+  fetchFileTree,
+  setExpandedNodes,
+  setSearchQuery,
+} from '../../../../src/store/slices/fileTreeSlice';
 
 const mockStore = configureStore([thunk]);
 
@@ -15,6 +21,7 @@ jest.mock('../../../../src/store/slices/fileTreeSlice', () => ({
   }),
   expandAllNodes: jest.fn((payload) => ({ type: 'fileTree/expandAllNodes', payload })),
   setExpandedNodes: jest.fn((payload) => ({ type: 'fileTree/setExpandedNodes', payload })),
+  ensureExpandedNodes: jest.fn((payload) => ({ type: 'fileTree/ensureExpandedNodes', payload })),
   setFilteredFileTree: jest.fn((payload) => ({ type: 'fileTree/setFilteredFileTree', payload }))
 }));
 
@@ -39,6 +46,7 @@ describe('FileTree', () => {
   };
 
   beforeEach(() => {
+    jest.clearAllMocks();
     store = mockStore(initialState);
     jest.spyOn(store, 'dispatch');
   });
@@ -183,5 +191,45 @@ describe('FileTree', () => {
         payload: [],
       });
     });
+  });
+
+  test('expands ancestor folders for the selected file path', () => {
+    render(
+      <Provider store={store}>
+        <FileTree
+          onFileSelect={jest.fn()}
+          isOpen={true}
+          onToggle={jest.fn()}
+          selectedFilePath="folder1/nested/file1.md"
+        />
+      </Provider>
+    );
+
+    expect(store.dispatch).toHaveBeenCalledWith(
+      ensureExpandedNodes(['folder1', 'folder1/nested'])
+    );
+  });
+
+  test('does not expand ancestors while the file tree is loading', () => {
+    store = mockStore({
+      fileTree: {
+        ...initialState.fileTree,
+        loading: true,
+      },
+    });
+    jest.spyOn(store, 'dispatch');
+
+    render(
+      <Provider store={store}>
+        <FileTree
+          onFileSelect={jest.fn()}
+          isOpen={true}
+          onToggle={jest.fn()}
+          selectedFilePath="folder1/file1.md"
+        />
+      </Provider>
+    );
+
+    expect(ensureExpandedNodes).not.toHaveBeenCalled();
   });
 });

--- a/packages/frontend/test/unit/components/LeftPane/FileTreeContent/FileTreeContent.test.tsx
+++ b/packages/frontend/test/unit/components/LeftPane/FileTreeContent/FileTreeContent.test.tsx
@@ -44,6 +44,7 @@ describe('FileTreeContent', () => {
         loading={true}
         error={null}
         expandedNodes={[]}
+        selectedFilePath={null}
         onFileSelect={jest.fn()}
         onExpandedItemsChange={jest.fn()}
       />
@@ -58,6 +59,7 @@ describe('FileTreeContent', () => {
         loading={false}
         error="Failed to load tree"
         expandedNodes={[]}
+        selectedFilePath={null}
         onFileSelect={jest.fn()}
         onExpandedItemsChange={jest.fn()}
       />
@@ -72,6 +74,7 @@ describe('FileTreeContent', () => {
         loading={false}
         error={null}
         expandedNodes={['folder1']}
+        selectedFilePath={null}
         onFileSelect={jest.fn()}
         onExpandedItemsChange={jest.fn()}
       />
@@ -88,6 +91,7 @@ describe('FileTreeContent', () => {
         loading={true}
         error={null}
         expandedNodes={['folder1']}
+        selectedFilePath={null}
         onFileSelect={jest.fn()}
         onExpandedItemsChange={jest.fn()}
       />
@@ -104,6 +108,7 @@ describe('FileTreeContent', () => {
           loading={false}
           error={null}
           expandedNodes={[]}
+          selectedFilePath={null}
           onFileSelect={jest.fn()}
           onExpandedItemsChange={jest.fn()}
         />
@@ -131,6 +136,7 @@ describe('FileTreeContent', () => {
         loading={false}
         error={null}
         expandedNodes={[]}
+        selectedFilePath={null}
         onFileSelect={onFileSelectMock}
         onExpandedItemsChange={jest.fn()}
       />
@@ -147,6 +153,7 @@ describe('FileTreeContent', () => {
         loading={false}
         error={null}
         expandedNodes={[]}
+        selectedFilePath={null}
         onFileSelect={jest.fn()}
         onExpandedItemsChange={onExpandedItemsChangeMock}
       />

--- a/packages/frontend/test/unit/components/LeftPane/FileTreeContent/FileTreeView.test.tsx
+++ b/packages/frontend/test/unit/components/LeftPane/FileTreeContent/FileTreeView.test.tsx
@@ -1,31 +1,58 @@
-import { render } from '@testing-library/react';
+import { act, render, waitFor } from '@testing-library/react';
 import React from 'react';
 import { FileTreeView } from '../../../../../src/components/LeftPane/FileTreeContent/FileTreeView';
 
 describe('FileTreeView', () => {
-  it('should render correctly', () => {
-    const filteredFileTree = [
-      { path: 'file1.md', status: 'added' },
-      { 'dir1': [{ path: 'dir1/file2.md', status: 'modified' }] },
-    ];
-    const expandedNodes = ['dir1'];
-    const onFileSelect = jest.fn();
-    const onExpandedItemsChange = jest.fn();
-    const getStatusColor = jest.fn((status) => {
-      if (status === 'added') return 'green';
-      if (status === 'modified') return 'blue';
-      return 'black';
-    });
+  const filteredFileTree = [
+    { path: 'file1.md', status: 'added' },
+    { 'dir1': [{ path: 'dir1/file2.md', status: 'modified' }] },
+  ];
+  const expandedNodes = ['dir1'];
+  const onFileSelect = jest.fn();
+  const onExpandedItemsChange = jest.fn();
+  const getStatusColor = jest.fn((status) => {
+    if (status === 'added') return 'green';
+    if (status === 'modified') return 'blue';
+    return 'black';
+  });
 
+  it('should render correctly', () => {
     const { asFragment } = render(
       <FileTreeView
         filteredFileTree={filteredFileTree}
         expandedNodes={expandedNodes}
+        selectedFilePath="dir1/file2.md"
         onFileSelect={onFileSelect}
         onExpandedItemsChange={onExpandedItemsChange}
         getStatusColor={getStatusColor}
       />
     );
     expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('scrolls the selected file into view', async () => {
+    const scrollIntoViewMock = jest.fn();
+    window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
+
+    render(
+      <FileTreeView
+        filteredFileTree={filteredFileTree}
+        expandedNodes={expandedNodes}
+        selectedFilePath="dir1/file2.md"
+        onFileSelect={onFileSelect}
+        onExpandedItemsChange={onExpandedItemsChange}
+        getStatusColor={getStatusColor}
+      />
+    );
+
+    await act(async () => {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 200);
+      });
+    });
+
+    await waitFor(() => {
+      expect(scrollIntoViewMock).toHaveBeenCalledWith({ block: 'nearest', behavior: 'smooth' });
+    });
   });
 });

--- a/packages/frontend/test/unit/components/LeftPane/FileTreeContent/__snapshots__/FileTreeView.test.tsx.snap
+++ b/packages/frontend/test/unit/components/LeftPane/FileTreeContent/__snapshots__/FileTreeView.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`FileTreeView should render correctly 1`] = `
       id="mui-tree-view-1-file1.md"
       role="treeitem"
       style="--TreeView-itemDepth: 0;"
-      tabindex="0"
+      tabindex="-1"
     >
       <div
         class="MuiTreeItem-content MuiSimpleTreeView-itemContent css-lz1n60-MuiTreeItem-content"
@@ -60,7 +60,7 @@ exports[`FileTreeView should render correctly 1`] = `
       </div>
     </li>
     <li
-      aria-checked="false"
+      aria-checked="mixed"
       aria-expanded="true"
       class="MuiTreeItem-root MuiSimpleTreeView-root css-jq3mgl-MuiTreeItem-root"
       id="mui-tree-view-1-dir1"
@@ -124,15 +124,16 @@ exports[`FileTreeView should render correctly 1`] = `
             class="MuiCollapse-wrapperInner MuiCollapse-vertical css-1i4ywhz-MuiCollapse-wrapperInner"
           >
             <li
-              aria-checked="false"
+              aria-checked="true"
               class="MuiTreeItem-root MuiSimpleTreeView-root css-jq3mgl-MuiTreeItem-root"
               id="mui-tree-view-1-dir1/file2.md"
               role="treeitem"
               style="--TreeView-itemDepth: 1;"
-              tabindex="-1"
+              tabindex="0"
             >
               <div
                 class="MuiTreeItem-content MuiSimpleTreeView-itemContent css-lz1n60-MuiTreeItem-content"
+                data-selected=""
               >
                 <div
                   class="MuiTreeItem-iconContainer MuiSimpleTreeView-itemIconContainer css-bt3rqe-MuiTreeItem-iconContainer"

--- a/packages/frontend/test/unit/store/fileTreeSlice.test.ts
+++ b/packages/frontend/test/unit/store/fileTreeSlice.test.ts
@@ -1,7 +1,9 @@
 import { configureStore } from '@reduxjs/toolkit';
 import fileTreeReducer, {
+  ensureExpandedNodes,
   expandAllNodes,
   fetchFileTree,
+  getAncestorPaths,
   selectFilteredFileTree,
   setExpandedNodes,
   setMountedDirectoryPath,
@@ -123,6 +125,42 @@ describe('fileTreeSlice', () => {
     store.dispatch(setExpandedNodes(['node1', 'node2']));
     expect(store.getState().fileTree.expandedNodes).toEqual(['node1', 'node2']);
     expect(localStorage.getItem('mdts_expanded_nodes_/test/path')).toEqual(JSON.stringify(['node1', 'node2']));
+  });
+
+  it('should handle ensureExpandedNodes by merging missing paths only', () => {
+    store.dispatch(setMountedDirectoryPath('/test/path'));
+    store.dispatch(setExpandedNodes(['dir1']));
+    store.dispatch(ensureExpandedNodes(['dir1', 'dir1/dir2', 'dir1/dir2/dir3']));
+
+    expect(store.getState().fileTree.expandedNodes).toEqual([
+      'dir1',
+      'dir1/dir2',
+      'dir1/dir2/dir3',
+    ]);
+    expect(localStorage.getItem('mdts_expanded_nodes_/test/path')).toEqual(JSON.stringify([
+      'dir1',
+      'dir1/dir2',
+      'dir1/dir2/dir3',
+    ]));
+  });
+
+  it('should not rewrite storage when ensureExpandedNodes has no missing paths', () => {
+    store.dispatch(setMountedDirectoryPath('/test/path'));
+    store.dispatch(setExpandedNodes(['dir1', 'dir1/dir2']));
+    const setItemSpy = jest.spyOn(localStorage, 'setItem');
+    setItemSpy.mockClear();
+
+    store.dispatch(ensureExpandedNodes(['dir1', 'dir1/dir2']));
+
+    expect(store.getState().fileTree.expandedNodes).toEqual(['dir1', 'dir1/dir2']);
+    expect(setItemSpy).not.toHaveBeenCalled();
+    setItemSpy.mockRestore();
+  });
+
+  it('should derive ancestor paths for nested files', () => {
+    expect(getAncestorPaths('file.md')).toEqual([]);
+    expect(getAncestorPaths('dir1/file.md')).toEqual(['dir1']);
+    expect(getAncestorPaths('dir1/dir2/file.md')).toEqual(['dir1', 'dir1/dir2']);
   });
 
   it('should handle expandAllNodes', () => {


### PR DESCRIPTION
## Summary
- Highlight the currently open document in the left file tree via `selectedItems`
- Expand ancestor folders when the path changes or the tree finishes loading (`ensureExpandedNodes`)
- Scroll the selected item into view so deep files stay visible after navigation

## Test plan
- [ ] Open a nested markdown file (e.g. `docs/a/b/file.md`) and confirm the sidebar expands parents, selects the file, and scrolls it into view
- [ ] Navigate between files and confirm selection follows `currentPath` without collapsing unrelated expanded folders
- [ ] Manually collapse a parent while a nested file is open; confirm it is not forcibly re-expanded until the path changes
- [ ] `cd packages/frontend && npm test -- --testPathPatterns='FileTree|fileTreeSlice'`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically expands folders leading to the currently selected file.
  * Scrolls the selected file into view in the file tree with smooth positioning.
  * Preserves expanded folder state for easier navigation.

* **Tests**
  * Added coverage for automatic folder expansion, selected-file scrolling, loading states, and expanded-state persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->