### PR TITLE
fix(server): handle permission-denied directories gracefully

### DIFF
--- a/src/server/routes/filetree.ts
+++ b/src/server/routes/filetree.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import simpleGit, { SimpleGit, StatusResult, FileStatusResult } from 'simple-git';
 import { EXCLUDED_DIRECTORIES } from '../../constants';
 import { ServerContext } from '../context';
+import { logger } from '../../utils/logger';
 import { resolveGlobPatterns } from '../../utils/glob';
 
 type FileTreeItem = { path: string, status: string, isDirectory?: boolean } | { [key: string]: FileTree };
@@ -37,6 +38,20 @@ const isDotFileOrDirectory = (entryName: string): boolean => {
 
 const shouldIncludeEntry = (entry: Dirent): boolean => {
   return !isDotFileOrDirectory(entry.name) && !EXCLUDED_DIRECTORIES.includes(entry.name);
+};
+
+// Errors that mean "this directory can't be enumerated" — skip it and keep going
+// rather than failing the whole file tree. EACCES/EPERM cover permission denials;
+// ENOENT/ENOTDIR cover races where the entry vanishes or isn't a directory.
+const UNREADABLE_DIRECTORY_ERROR_CODES = ['EACCES', 'EPERM', 'ENOENT', 'ENOTDIR'];
+
+const isUnreadableDirectoryError = (error: unknown): boolean => {
+  return Boolean(
+    error &&
+      typeof error === 'object' &&
+      'code' in error &&
+      UNREADABLE_DIRECTORY_ERROR_CODES.includes((error as NodeJS.ErrnoException).code as string),
+  );
 };
 
 const buildFileTreeFromPatterns = (
@@ -95,10 +110,16 @@ const getFileTree = async (
   gitStatus: StatusResult | null
 ): Promise<FileTree> => {
   const fullPath = path.join(baseDirectory, currentRelativePath);
-  const entriesInDir = fs.readdirSync(
-    fullPath,
-    { withFileTypes: true }
-  );
+  let entriesInDir: Dirent[];
+  try {
+    entriesInDir = fs.readdirSync(fullPath, { withFileTypes: true });
+  } catch (error) {
+    if (isUnreadableDirectoryError(error)) {
+      logger.log('Server', `🔒 Skipping inaccessible directory: ${currentRelativePath || fullPath}`);
+      return [];
+    }
+    throw error;
+  }
   const entries = entriesInDir.filter(shouldIncludeEntry);
 
   const tree: FileTree = [];

--- a/src/server/routes/filetree.ts
+++ b/src/server/routes/filetree.ts
@@ -5,6 +5,7 @@ import simpleGit, { SimpleGit, StatusResult, FileStatusResult } from 'simple-git
 import { EXCLUDED_DIRECTORIES } from '../../constants';
 import { ServerContext } from '../context';
 import { logger } from '../../utils/logger';
+import { isUnreadableDirectoryError } from '../../utils/errors';
 import { resolveGlobPatterns } from '../../utils/glob';
 
 type FileTreeItem = { path: string, status: string, isDirectory?: boolean } | { [key: string]: FileTree };
@@ -38,20 +39,6 @@ const isDotFileOrDirectory = (entryName: string): boolean => {
 
 const shouldIncludeEntry = (entry: Dirent): boolean => {
   return !isDotFileOrDirectory(entry.name) && !EXCLUDED_DIRECTORIES.includes(entry.name);
-};
-
-// Errors that mean "this directory can't be enumerated" — skip it and keep going
-// rather than failing the whole file tree. EACCES/EPERM cover permission denials;
-// ENOENT/ENOTDIR cover races where the entry vanishes or isn't a directory.
-const UNREADABLE_DIRECTORY_ERROR_CODES = ['EACCES', 'EPERM', 'ENOENT', 'ENOTDIR'];
-
-const isUnreadableDirectoryError = (error: unknown): boolean => {
-  return Boolean(
-    error &&
-      typeof error === 'object' &&
-      'code' in error &&
-      UNREADABLE_DIRECTORY_ERROR_CODES.includes((error as NodeJS.ErrnoException).code as string),
-  );
 };
 
 const buildFileTreeFromPatterns = (

--- a/src/server/watcher.ts
+++ b/src/server/watcher.ts
@@ -67,6 +67,25 @@ const attachTreeReloadHandlers = (watcher: FSWatcher, wss: WebSocketServer): voi
   });
 };
 
+// A permission error on a single path is non-fatal: chokidar keeps watching
+// everything else, so we just skip that path instead of tearing down the watcher.
+const isPermissionError = (error: unknown): boolean => {
+  return Boolean(
+    error &&
+      typeof error === 'object' &&
+      'code' in error &&
+      ['EACCES', 'EPERM'].includes((error as NodeJS.ErrnoException).code as string),
+  );
+};
+
+const describeWatchTarget = (error: unknown, directory: string): string => {
+  const errorPath = (error as NodeJS.ErrnoException)?.path;
+  if (typeof errorPath !== 'string') return 'a path';
+  return errorPath.startsWith(`${directory}/`)
+    ? errorPath.slice(directory.length + 1)
+    : errorPath;
+};
+
 const setupDirectoryWatcher = (directory: string, wss: WebSocketServer): FSWatcher | null => {
   try {
     const watcher = chokidar.watch(directory, {
@@ -89,6 +108,15 @@ const setupDirectoryWatcher = (directory: string, wss: WebSocketServer): FSWatch
     attachTreeReloadHandlers(watcher, wss);
 
     watcher.on('error', (error) => {
+      if (isPermissionError(error)) {
+        const target = describeWatchTarget(error, directory);
+        logger.log(
+          'Livereload',
+          `🔒 Can't watch "${target}" (permission denied); live-reload skipped for it, others still watched.`,
+        );
+        return;
+      }
+
       watcher.unwatch(directory);
       watcher.close()
         .then(() => logger.log('Livereload', 'Directory watcher closed'));
@@ -119,6 +147,14 @@ const setupFilePatternWatcher = (context: ServerContext, wss: WebSocketServer): 
     attachTreeReloadHandlers(watcher, wss);
 
     watcher.on('error', (error) => {
+      if (isPermissionError(error)) {
+        const target = describeWatchTarget(error, directory);
+        logger.log(
+          'Livereload',
+          `🔒 Can't watch "${target}" (permission denied); live-reload skipped for it, others still watched.`,
+        );
+        return;
+      }
       watcher.close()
         .then(() => logger.log('Livereload', 'File pattern watcher closed'));
       logger.error('🚫 Error watching files:', error);

--- a/src/server/watcher.ts
+++ b/src/server/watcher.ts
@@ -4,6 +4,7 @@ import * as http from 'http';
 import path from 'path';
 import { WebSocket, WebSocketServer } from 'ws';
 import { logger } from '../utils/logger';
+import { isPermissionError } from '../utils/errors';
 import { EXCLUDED_DIRECTORIES } from '../constants';
 import { ServerContext } from './context';
 
@@ -67,14 +68,11 @@ const attachTreeReloadHandlers = (watcher: FSWatcher, wss: WebSocketServer): voi
   });
 };
 
-// A permission error on a single path is non-fatal: chokidar keeps watching
-// everything else, so we just skip that path instead of tearing down the watcher.
-const isPermissionError = (error: unknown): boolean => {
-  return Boolean(
-    error &&
-      typeof error === 'object' &&
-      'code' in error &&
-      ['EACCES', 'EPERM'].includes((error as NodeJS.ErrnoException).code as string),
+const logSkippedWatchTarget = (error: unknown, directory: string): void => {
+  const target = describeWatchTarget(error, directory);
+  logger.log(
+    'Livereload',
+    `🔒 Can't watch "${target}" (permission denied); live-reload skipped for it, others still watched.`,
   );
 };
 
@@ -108,14 +106,7 @@ const setupDirectoryWatcher = (directory: string, wss: WebSocketServer): FSWatch
     attachTreeReloadHandlers(watcher, wss);
 
     watcher.on('error', (error) => {
-      if (isPermissionError(error)) {
-        const target = describeWatchTarget(error, directory);
-        logger.log(
-          'Livereload',
-          `🔒 Can't watch "${target}" (permission denied); live-reload skipped for it, others still watched.`,
-        );
-        return;
-      }
+      if (isPermissionError(error)) return logSkippedWatchTarget(error, directory);
 
       watcher.unwatch(directory);
       watcher.close()
@@ -147,14 +138,8 @@ const setupFilePatternWatcher = (context: ServerContext, wss: WebSocketServer): 
     attachTreeReloadHandlers(watcher, wss);
 
     watcher.on('error', (error) => {
-      if (isPermissionError(error)) {
-        const target = describeWatchTarget(error, directory);
-        logger.log(
-          'Livereload',
-          `🔒 Can't watch "${target}" (permission denied); live-reload skipped for it, others still watched.`,
-        );
-        return;
-      }
+      if (isPermissionError(error)) return logSkippedWatchTarget(error, directory);
+
       watcher.close()
         .then(() => logger.log('Livereload', 'File pattern watcher closed'));
       logger.error('🚫 Error watching files:', error);

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,0 +1,21 @@
+const PERMISSION_ERROR_CODES = ['EACCES', 'EPERM'];
+
+// ENOENT/ENOTDIR cover races where the entry vanishes or isn't a directory anymore.
+const UNREADABLE_DIRECTORY_ERROR_CODES = [...PERMISSION_ERROR_CODES, 'ENOENT', 'ENOTDIR'];
+
+export const hasErrnoCode = (error: unknown, codes: string[]): boolean => {
+  return typeof error === 'object'
+    && error !== null
+    && 'code' in error
+    && codes.includes((error as NodeJS.ErrnoException).code ?? '');
+};
+
+// A permission error on a single path is non-fatal: chokidar keeps watching
+// everything else, so we just skip that path instead of tearing down the watcher.
+export const isPermissionError = (error: unknown): boolean =>
+  hasErrnoCode(error, PERMISSION_ERROR_CODES);
+
+// Errors that mean "this directory can't be enumerated" - skip it and keep going
+// rather than failing the whole file tree.
+export const isUnreadableDirectoryError = (error: unknown): boolean =>
+  hasErrnoCode(error, UNREADABLE_DIRECTORY_ERROR_CODES);

--- a/test/unit/server/routes/filetree.test.ts
+++ b/test/unit/server/routes/filetree.test.ts
@@ -74,6 +74,27 @@ describe('filetree.ts', () => {
         isGitRepository: true,
       });
     });
+
+    it('should skip inaccessible directories (EACCES) and still return the rest of the tree', async () => {
+      (fs.readdirSync as jest.Mock)
+        .mockReturnValueOnce([ // For root: an unreadable dir + a readable markdown file
+          mockDirent('inaccessible', true),
+          mockDirent('file1.md', false),
+        ])
+        .mockImplementationOnce(() => { // For inaccessible: permission denied
+          const error = new Error('permission denied') as NodeJS.ErrnoException;
+          error.code = 'EACCES';
+          throw error;
+        });
+
+      const response = await request(app).get('/api/filetree');
+      expect(response.statusCode).toBe(200);
+      expect(response.body).toEqual({
+        fileTree: [{ path: 'file1.md', status: ' ' }],
+        mountedDirectoryPath: mockDirectory,
+        isGitRepository: true,
+      });
+    });
   });
 
   describe('fileTreeRouter with file patterns', () => {

--- a/test/unit/server/watcher.test.ts
+++ b/test/unit/server/watcher.test.ts
@@ -269,6 +269,26 @@ describe('watcher.ts unit tests', () => {
         'This error is likely caused by too many open files. Try increasing the ulimit.',
       );
     });
+
+    it('should log a friendly message and keep watching on permission error (EACCES)', async () => {
+      const onErrorCallback = (mockDirectoryWatcher.on as jest.Mock).mock.calls.find(call => call[0] === 'error')[1];
+      const error = Object.assign(new Error('permission denied'), {
+        code: 'EACCES',
+        path: '/mock/directory/secret',
+      });
+
+      onErrorCallback(error);
+      await Promise.resolve();
+
+      // Permission errors are non-fatal: do not tear down the watcher.
+      expect(mockDirectoryWatcher.unwatch).not.toHaveBeenCalled();
+      expect(mockDirectoryWatcher.close).not.toHaveBeenCalled();
+      expect(logger.log).toHaveBeenCalledWith(
+        'Livereload',
+        '🔒 Can\'t watch "secret" (permission denied); live-reload skipped for it, others still watched.',
+      );
+      expect(logger.error).not.toHaveBeenCalled();
+    });
   });
 
   describe('chokidar ignored option', () => {
@@ -401,6 +421,31 @@ describe('watcher.ts unit tests', () => {
 
       expect(logger.error).toHaveBeenCalledWith('🚫 Error watching files:', expect.any(Error));
       expect(logger.error).toHaveBeenCalledWith('Livereload will be disabled');
+    });
+
+    it('should log a friendly message and keep watching on permission error (EACCES)', async () => {
+      setupWatcher(
+        { directory: '/mock/directory', filePatterns: ['a.md'] },
+        mockServer,
+        3000,
+      );
+
+      const onErrorCallback = (mockPatternWatcher.on as jest.Mock).mock.calls
+        .find(call => call[0] === 'error')[1];
+      const error = Object.assign(new Error('permission denied'), {
+        code: 'EACCES',
+        path: '/mock/directory/a.md',
+      });
+
+      onErrorCallback(error);
+      await Promise.resolve();
+
+      expect(mockPatternWatcher.close).not.toHaveBeenCalled();
+      expect(logger.log).toHaveBeenCalledWith(
+        'Livereload',
+        '🔒 Can\'t watch "a.md" (permission denied); live-reload skipped for it, others still watched.',
+      );
+      expect(logger.error).not.toHaveBeenCalled();
     });
   });
 });

--- a/test/unit/utils/errors.test.ts
+++ b/test/unit/utils/errors.test.ts
@@ -1,0 +1,47 @@
+import { hasErrnoCode, isPermissionError, isUnreadableDirectoryError } from '../../../src/utils/errors';
+
+const errorWithCode = (code: string): NodeJS.ErrnoException =>
+  Object.assign(new Error(code), { code });
+
+describe('hasErrnoCode', () => {
+  it('should return true when the error carries one of the given codes', () => {
+    expect(hasErrnoCode(errorWithCode('EMFILE'), ['EMFILE', 'EACCES'])).toBe(true);
+  });
+
+  it('should return false for a different code', () => {
+    expect(hasErrnoCode(errorWithCode('EMFILE'), ['EACCES'])).toBe(false);
+  });
+
+  it('should return false for an error without a code', () => {
+    expect(hasErrnoCode(new Error('boom'), ['EACCES'])).toBe(false);
+  });
+
+  it('should return false when the code property is undefined', () => {
+    expect(hasErrnoCode(Object.assign(new Error('boom'), { code: undefined }), ['EACCES'])).toBe(false);
+  });
+
+  it('should return false for non-error values', () => {
+    expect(hasErrnoCode(null, ['EACCES'])).toBe(false);
+    expect(hasErrnoCode('EACCES', ['EACCES'])).toBe(false);
+  });
+});
+
+describe('isPermissionError', () => {
+  it.each(['EACCES', 'EPERM'])('should return true for %s', (code) => {
+    expect(isPermissionError(errorWithCode(code))).toBe(true);
+  });
+
+  it.each(['ENOENT', 'ENOTDIR', 'EMFILE'])('should return false for %s', (code) => {
+    expect(isPermissionError(errorWithCode(code))).toBe(false);
+  });
+});
+
+describe('isUnreadableDirectoryError', () => {
+  it.each(['EACCES', 'EPERM', 'ENOENT', 'ENOTDIR'])('should return true for %s', (code) => {
+    expect(isUnreadableDirectoryError(errorWithCode(code))).toBe(true);
+  });
+
+  it('should return false for an unrelated code', () => {
+    expect(isUnreadableDirectoryError(errorWithCode('EMFILE'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a crash where running `npx mdts` in a folder that contains a sub-directory the process can't read made the whole tree view unusable (`Error: EACCES: permission denied, scandir ...`). Inaccessible directories are now skipped gracefully — in both the file-tree API and the livereload watcher — with a single friendly log line, and no scary error/stack trace.

## Problem

When mdts is started (zero-config, no `--glob`) inside a directory tree that has an unreadable sub-folder, two things break:

1. **The file tree never loads.** `GET /api/filetree` returns HTTP 500. `getFileTree` calls `fs.readdirSync` recursively with no error handling; the first unreadable sub-directory throws `EACCES`, the async Express 5 handler rejects, and with no error handler registered the default 500 is returned. The frontend's tree panel is left blank — the app appears completely broken.
2. **The console spews a scary error.** chokidar's livereload watcher hits `EACCES` on the same directory and the `error` handler prints the raw error with a full stack trace, then tears down the **entire** watcher and disables livereload — even though a single unreadable path is non-fatal.

There was no simple workaround: no `--exclude` flag exists, `EXCLUDED_DIRECTORIES` is hardcoded, and `--glob` only helps if the user already knows and lists every markdown path.

## Root cause

- `src/server/routes/filetree.ts` — `getFileTree` used `fs.readdirSync(...)` with no `try/catch`.
- `src/server/watcher.ts` — the chokidar `error` handler treated every error as fatal. Per chokidar's own `_handleError`, `EACCES`/`EPERM` on one path is non-fatal: that path simply isn't watched while the rest continue.

## Changes

### 1. File tree — skip unreadable directories (`getFileTree`)
Wrapped `readdirSync` in a `try/catch`. The "can't enumerate this directory" error family (`EACCES`, `EPERM`, plus the `ENOENT`/`ENOTDIR` races where an entry vanishes mid-scan) logs a skip and returns an empty sub-tree so the rest renders:

```
 Server   🔒 Skipping inaccessible directory: compose/data/timescale
```

Unexpected errors still propagate (still a 500), so genuine failures aren't hidden.

### 2. Livereload — keep watching on permission errors
Both watchers (directory and file-pattern) now detect permission errors, log one friendly line, and **leave the watcher running**:

```
 Livereload   🔒 Can't watch "compose/data/timescale" (permission denied); live-reload skipped for it, others still watched.
```

Genuinely fatal errors keep the existing teardown + guidance (e.g. the `EMFILE` hint).

| | Before | After |
| --- | --- | --- |
| `GET /api/filetree` | HTTP 500, blank tree | HTTP 200, full tree (minus unreadable dirs) |
| Console on unreadable dir | red `🚫 Error ...` + stack trace + "Livereload will be disabled" | one `🔒 ...` info line |
| Livereload | disabled globally | continues for all readable paths |

## Verification

Tested by launching against a real folder containing an unreadable sub-directory (`compose/data/timescale` → `Permission denied`):

```bash
node dist/index.js /path/to/folder -H 0.0.0.0 -p 8531 --no-open
```

- ✅ `GET /api/filetree` → **HTTP 200**; tree renders all top-level entries; `timescale` absent, rest intact
- ✅ Skip log fired for the unreadable directory
- ✅ Console clean — no `error` / `🚫` / stack trace / "disabled" lines
- ✅ Watcher not torn down (no "Directory watcher closed"); livereload still active for readable files
- ✅ `npm test` — **123 passed** (13 suites), incl. new regression tests
- ✅ `npm run lint` — clean (30 files)

### New tests
- `test/unit/server/routes/filetree.test.ts` — `readdirSync` throws `EACCES` → endpoint returns 200 with the rest of the tree.
- `test/unit/server/watcher.test.ts` — `EACCES` error event → friendly log, **no** `close`/`unwatch`, **no** `logger.error` (for both directory and file-pattern watchers).

## Notes

- No CLI changes — zero-config `npx mdts` continues to "just work".
- No breaking changes; only previously-fatal permission paths are now non-fatal.
- Touched only the default (non-glob) file-tree path; the `--glob` path already avoided `readdirSync`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * File tree responses now continue when encountering inaccessible directories, skipping only those subtrees while keeping available readable files.
  * Live reload now ignores permission-denied watcher targets instead of disabling live reload for the whole setup.
  * Permission-denied cases produce clearer, target-specific “skipped due to permission” messages rather than generic interruption.
* **Tests**
  * Added unit tests for file tree handling of unreadable directories and watcher behavior on `EACCES` permission errors.
  * Added unit tests for new error classification helpers used by these flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->