### PR TITLE
fix(frontend): style h6 and drop unused markdown CSS variables

### DIFF
--- a/packages/frontend/public/markdown.css
+++ b/packages/frontend/public/markdown.css
@@ -1,15 +1,11 @@
 :root {
     --markdown-border-color: rgba(0, 0, 0, .12);
-    --markdown-pre-background-color: #f4f5f7;
-    --markdown-code-background-color: #f4f5f7;
     --markdown-blockquote-color: rgba(0, 0, 0, .24);
     --markdown-link-color: #1976d2;
 }
 
 [data-theme="dark"] {
     --markdown-border-color: rgba(255, 255, 255, .12);
-    --markdown-pre-background-color: #161819;
-    --markdown-code-background-color: #161819;
     --markdown-blockquote-color: rgba(255, 255, 255, .24);
 }
 
@@ -37,13 +33,7 @@
         font-weight: 500;
     }
 
-    h4 {
-        margin: 48px 0 24px;
-        font-size: 1.143rem;
-        font-weight: 400;
-    }
-
-    h5 {
+    h4, h5, h6 {
         margin: 48px 0 24px;
         font-size: 1.143rem;
         font-weight: 400;


### PR DESCRIPTION
## Summary

Addresses two of the three points raised in #857.

- `h6` had no rule at all, so it missed the `margin` / `font-weight` treatment shared by `h1` through `h5`. Merged into the `h4` / `h5` rule, which already had byte-identical declarations.
- Removed `--markdown-pre-background-color` and `--markdown-code-background-color`. Both were declared in `:root` and `[data-theme="dark"]` but referenced zero times.

## Why the variables are removed rather than wired up

The issue suggests wiring the two variables into `.markdown-body pre` / `.markdown-body code`. That would conflict with how code rendering actually works today.

- Code blocks are rendered by `PrismAsyncLight` in `MarkdownCode.tsx`, which applies the style of the syntax highlighter theme the user selects in Settings.
- Inline code takes its background from `syntaxHighlighterThemeMeta.color` in the same component.

Both follow the selected syntax highlighter theme by design, so a CSS background would fight the user's choice. The variables are leftovers from before that behavior moved into the component.

## Heading colors are intentionally left alone

The third point in the issue, adding a `color` to headings, is not included. The current CSS conveys hierarchy through font size plus a `border-bottom` on `h1` / `h2`, which matches the convention GitHub's own Markdown rendering uses. Discussion continues on the issue.

## Visual impact

`h6` only. It moves from browser defaults to the same treatment as `h4` / `h5`. Nothing else changes, since the removed variables had no effect.

Refs #857

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated Markdown heading styles for more consistent formatting across lower-level headings.
  * Adjusted Markdown color handling, including code blocks and dark theme presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->