### PR TITLE
feat: expand compact content width for overflowing tables

### DIFF
--- a/docs/frontend_features.md
+++ b/docs/frontend_features.md
@@ -58,7 +58,7 @@ The UI is divided into three panels—file tree, document view, and outline—ma
 `mdts` provides an advanced settings dialog (accessible via the gear icon) with three main configuration tabs:
 
 ### 🎨 Layout Settings
-- **Content Width**: Toggle between `compact` (centered, focused reading) and `full-width` (spans entire screen) layouts
+- **Content Width**: Toggle between `compact` (centered, focused reading; expands to use leftover screen space when tables or other wide content would otherwise scroll) and `full-width` (spans entire screen) layouts
 - **Responsive Design**: Automatically adjusts to different screen sizes
 
 ### 🌈 Color Scheme Settings  

--- a/packages/frontend/src/components/Content/MarkdownContent/MarkdownContent.tsx
+++ b/packages/frontend/src/components/Content/MarkdownContent/MarkdownContent.tsx
@@ -2,6 +2,7 @@ import { ArticleOutlined } from '@mui/icons-material';
 import { Box, Chip, Typography } from '@mui/material';
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import useCompactContentWidth from '../../../hooks/useCompactContentWidth';
 import { useFrontmatter } from '../../../hooks/useFrontmatter';
 import useIsMobile from '../../../hooks/useIsMobile';
 import { useViewMode } from '../../../hooks/useViewMode';
@@ -31,6 +32,11 @@ const MarkdownContent: React.FC<MarkdownContentProps> = ({ scrollToId, onDirecto
   const viewMode = useViewMode();
   const isMobile = useIsMobile();
   const loading = contentLoading || fileTreeLoading;
+  const compactEnabled = contentMode === 'compact' && !isMobile;
+  const { ref: contentRef, width: compactWidth } = useCompactContentWidth(
+    compactEnabled,
+    `${currentPath}:${viewMode}:${content}`
+  );
 
   useEffect(() => {
     dispatch(fetchContent(currentPath));
@@ -73,6 +79,7 @@ const MarkdownContent: React.FC<MarkdownContentProps> = ({ scrollToId, onDirecto
 
   return (
     <Box
+      ref={contentRef}
       sx={{
         width: '100%',
         minWidth: 0,
@@ -80,8 +87,8 @@ const MarkdownContent: React.FC<MarkdownContentProps> = ({ scrollToId, onDirecto
         m: 0,
         p: isMobile ? 2 : 4,
         bgcolor: 'background.paper',
-        ...(contentMode === 'compact' && !isMobile && {
-          width: '800px',
+        ...(compactEnabled && {
+          width: `${compactWidth}px`,
           margin: '0 auto',
           borderRight: '1px solid',
           borderLeft: '1px solid',

--- a/packages/frontend/src/hooks/measureCompactContentWidth.ts
+++ b/packages/frontend/src/hooks/measureCompactContentWidth.ts
@@ -1,0 +1,43 @@
+export const COMPACT_CONTENT_WIDTH = 800;
+export const OVERFLOW_HOST_SELECTOR = '.table-wrapper, pre, .katex-display';
+export const OVERFLOW_SLACK_PX = 4;
+
+const WIDTH_EPSILON = 1;
+
+const parsePaddingPx = (value: string): number => {
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+const getHorizontalPadding = (element: HTMLElement): number => {
+  const { paddingLeft, paddingRight } = window.getComputedStyle(element);
+  return parsePaddingPx(paddingLeft) + parsePaddingPx(paddingRight);
+};
+
+const measureIntrinsicWidth = (element: HTMLElement): number => {
+  const previousWidth = element.style.width;
+  const previousMinWidth = element.style.minWidth;
+  element.style.width = 'max-content';
+  element.style.minWidth = 'max-content';
+  const width = element.scrollWidth;
+  element.style.width = previousWidth;
+  element.style.minWidth = previousMinWidth;
+  return width;
+};
+
+export const measureCompactContentWidth = (container: HTMLElement): number => {
+  const available = container.parentElement?.clientWidth ?? COMPACT_CONTENT_WIDTH;
+  const paddingX = getHorizontalPadding(container);
+  let required = COMPACT_CONTENT_WIDTH;
+
+  container.querySelectorAll<HTMLElement>(OVERFLOW_HOST_SELECTOR).forEach((element) => {
+    required = Math.max(required, measureIntrinsicWidth(element) + paddingX + OVERFLOW_SLACK_PX);
+  });
+
+  const cap = Math.max(available, COMPACT_CONTENT_WIDTH);
+  return Math.min(Math.max(required, COMPACT_CONTENT_WIDTH), cap);
+};
+
+export const isSameContentWidth = (left: number, right: number): boolean => (
+  Math.abs(left - right) < WIDTH_EPSILON
+);

--- a/packages/frontend/src/hooks/useCompactContentWidth.ts
+++ b/packages/frontend/src/hooks/useCompactContentWidth.ts
@@ -1,0 +1,58 @@
+import { RefObject, useLayoutEffect, useRef, useState } from 'react';
+import {
+  COMPACT_CONTENT_WIDTH,
+  isSameContentWidth,
+  measureCompactContentWidth,
+} from './measureCompactContentWidth';
+
+interface CompactContentWidth {
+  ref: RefObject<HTMLDivElement | null>;
+  width: number;
+}
+
+const useCompactContentWidth = (enabled: boolean, observeKey: unknown): CompactContentWidth => {
+  const ref = useRef<HTMLDivElement>(null);
+  const [width, setWidth] = useState(COMPACT_CONTENT_WIDTH);
+
+  useLayoutEffect(() => {
+    if (!enabled) {
+      setWidth(COMPACT_CONTENT_WIDTH);
+      return;
+    }
+
+    const container = ref.current;
+    if (!container) {
+      return;
+    }
+
+    const apply = () => {
+      const next = measureCompactContentWidth(container);
+      setWidth((previous) => (isSameContentWidth(previous, next) ? previous : next));
+    };
+
+    apply();
+
+    const parent = container.parentElement;
+    const observers: Array<{ disconnect: () => void }> = [];
+
+    if (typeof ResizeObserver !== 'undefined') {
+      const resizeObserver = new ResizeObserver(apply);
+      if (parent) {
+        resizeObserver.observe(parent);
+      }
+      observers.push(resizeObserver);
+    }
+
+    const mutationObserver = new MutationObserver(apply);
+    mutationObserver.observe(container, { childList: true, subtree: true });
+    observers.push(mutationObserver);
+
+    return () => {
+      observers.forEach((observer) => observer.disconnect());
+    };
+  }, [enabled, observeKey]);
+
+  return { ref, width };
+};
+
+export default useCompactContentWidth;

--- a/packages/frontend/test/unit/hooks/measureCompactContentWidth.test.ts
+++ b/packages/frontend/test/unit/hooks/measureCompactContentWidth.test.ts
@@ -1,0 +1,97 @@
+import {
+  COMPACT_CONTENT_WIDTH,
+  measureCompactContentWidth,
+} from '../../../src/hooks/measureCompactContentWidth';
+
+const setLayout = (element: HTMLElement, clientWidth: number, scrollWidth: number) => {
+  Object.defineProperty(element, 'clientWidth', { configurable: true, value: clientWidth });
+  Object.defineProperty(element, 'scrollWidth', { configurable: true, value: scrollWidth });
+};
+
+describe('measureCompactContentWidth', () => {
+  let parent: HTMLDivElement;
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    parent = document.createElement('div');
+    container = document.createElement('div');
+    parent.appendChild(container);
+    document.body.appendChild(parent);
+
+    jest.spyOn(window, 'getComputedStyle').mockImplementation((element) => {
+      if (element === container) {
+        return { paddingLeft: '32px', paddingRight: '32px' } as CSSStyleDeclaration;
+      }
+      return { paddingLeft: '0px', paddingRight: '0px' } as CSSStyleDeclaration;
+    });
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    jest.restoreAllMocks();
+  });
+
+  test('keeps compact width when there is no overflowing content', () => {
+    setLayout(parent, 1600, 1600);
+    setLayout(container, COMPACT_CONTENT_WIDTH, COMPACT_CONTENT_WIDTH);
+
+    expect(measureCompactContentWidth(container)).toBe(COMPACT_CONTENT_WIDTH);
+  });
+
+  test('expands to fit a wide table before using a scrollbar', () => {
+    setLayout(parent, 1600, 1600);
+    setLayout(container, COMPACT_CONTENT_WIDTH, COMPACT_CONTENT_WIDTH);
+
+    const tableWrapper = document.createElement('div');
+    tableWrapper.className = 'table-wrapper';
+    setLayout(tableWrapper, 736, 1200);
+    container.appendChild(tableWrapper);
+
+    expect(measureCompactContentWidth(container)).toBe(1268);
+  });
+
+  test('caps expansion at the available parent width', () => {
+    setLayout(parent, 1400, 1400);
+    setLayout(container, COMPACT_CONTENT_WIDTH, COMPACT_CONTENT_WIDTH);
+
+    const tableWrapper = document.createElement('div');
+    tableWrapper.className = 'table-wrapper';
+    setLayout(tableWrapper, 736, 2000);
+    container.appendChild(tableWrapper);
+
+    expect(measureCompactContentWidth(container)).toBe(1400);
+  });
+
+  test('expands for wide code blocks', () => {
+    setLayout(parent, 1800, 1800);
+    setLayout(container, COMPACT_CONTENT_WIDTH, COMPACT_CONTENT_WIDTH);
+
+    const pre = document.createElement('pre');
+    setLayout(pre, 736, 1500);
+    container.appendChild(pre);
+
+    expect(measureCompactContentWidth(container)).toBe(1568);
+  });
+
+  test('uses the widest overflowing host', () => {
+    setLayout(parent, 2000, 2000);
+    setLayout(container, COMPACT_CONTENT_WIDTH, COMPACT_CONTENT_WIDTH);
+
+    const tableWrapper = document.createElement('div');
+    tableWrapper.className = 'table-wrapper';
+    setLayout(tableWrapper, 736, 900);
+    const pre = document.createElement('pre');
+    setLayout(pre, 736, 1100);
+    container.appendChild(tableWrapper);
+    container.appendChild(pre);
+
+    expect(measureCompactContentWidth(container)).toBe(1168);
+  });
+
+  test('does not shrink below compact width when the parent is narrower', () => {
+    setLayout(parent, 600, 600);
+    setLayout(container, COMPACT_CONTENT_WIDTH, COMPACT_CONTENT_WIDTH);
+
+    expect(measureCompactContentWidth(container)).toBe(COMPACT_CONTENT_WIDTH);
+  });
+});

--- a/packages/frontend/test/unit/hooks/useCompactContentWidth.test.tsx
+++ b/packages/frontend/test/unit/hooks/useCompactContentWidth.test.tsx
@@ -1,0 +1,72 @@
+import { act, render, screen } from '@testing-library/react';
+import React from 'react';
+import useCompactContentWidth from '../../../src/hooks/useCompactContentWidth';
+import { COMPACT_CONTENT_WIDTH, measureCompactContentWidth } from '../../../src/hooks/measureCompactContentWidth';
+
+jest.mock('../../../src/hooks/measureCompactContentWidth', () => {
+  const actual = jest.requireActual('../../../src/hooks/measureCompactContentWidth');
+  return {
+    ...actual,
+    measureCompactContentWidth: jest.fn(() => 1200),
+  };
+});
+
+const mockedMeasure = measureCompactContentWidth as jest.MockedFunction<typeof measureCompactContentWidth>;
+
+const Harness: React.FC<{ enabled: boolean; observeKey?: unknown }> = ({ enabled, observeKey = 'doc' }) => {
+  const { ref, width } = useCompactContentWidth(enabled, observeKey);
+  return (
+    <div data-testid="container" ref={ref} data-width={width}>
+      content
+    </div>
+  );
+};
+
+describe('useCompactContentWidth', () => {
+  beforeEach(() => {
+    mockedMeasure.mockClear();
+    mockedMeasure.mockReturnValue(1200);
+  });
+
+  test('uses the measured width when compact mode is enabled', () => {
+    render(<Harness enabled />);
+    expect(screen.getByTestId('container')).toHaveAttribute('data-width', '1200');
+    expect(mockedMeasure).toHaveBeenCalled();
+  });
+
+  test('resets to compact width when disabled', () => {
+    const { rerender } = render(<Harness enabled />);
+    expect(screen.getByTestId('container')).toHaveAttribute('data-width', '1200');
+
+    rerender(<Harness enabled={false} />);
+    expect(screen.getByTestId('container')).toHaveAttribute('data-width', String(COMPACT_CONTENT_WIDTH));
+  });
+
+  test('remeasures when observeKey changes', () => {
+    const { rerender } = render(<Harness enabled observeKey="one" />);
+    expect(mockedMeasure).toHaveBeenCalledTimes(1);
+
+    rerender(<Harness enabled observeKey="two" />);
+    expect(mockedMeasure).toHaveBeenCalledTimes(2);
+  });
+
+  test('remeasures when the parent size changes', () => {
+    let resizeCallback: ResizeObserverCallback = () => undefined;
+    const observe = jest.fn();
+    const disconnect = jest.fn();
+    window.ResizeObserver = jest.fn((callback) => {
+      resizeCallback = callback;
+      return { observe, unobserve: jest.fn(), disconnect } as unknown as ResizeObserver;
+    });
+
+    render(<Harness enabled />);
+    expect(mockedMeasure).toHaveBeenCalledTimes(1);
+
+    mockedMeasure.mockReturnValue(1400);
+    act(() => {
+      resizeCallback([] as unknown as ResizeObserverEntry[], {} as ResizeObserver);
+    });
+
+    expect(screen.getByTestId('container')).toHaveAttribute('data-width', '1400');
+  });
+});


### PR DESCRIPTION
## Summary
- In compact mode, grow the centered content column when tables, code blocks, or wide math would overflow
- Use leftover space between the side panes first; only show a horizontal scrollbar after the column cannot grow further
- Keep the default 800px reading width when content does not overflow

## Test plan
- [ ] Open a markdown file with a wide table on a large screen (compact mode) and confirm the white column expands so the table is visible without scrolling
- [ ] Open a file with only paragraphs and confirm the column stays 800px with side margins
- [ ] Shrink the window or open both side panes until leftover space is gone and confirm the table wrapper then scrolls
- [ ] Toggle compact / full width in settings and confirm full width is unchanged
- [ ] `cd packages/frontend && npm test -- --testPathPatterns='measureCompactContentWidth|useCompactContentWidth|MarkdownContent.test'`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Compact content layouts now automatically expand to fit wide tables, code blocks, and other content.
  * Layout width adjusts when the surrounding container changes, reducing unnecessary horizontal scrolling.

* **Documentation**
  * Updated compact layout documentation to describe dynamic expansion behavior.

* **Tests**
  * Added coverage for content sizing, overflow handling, resizing, and layout state changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->