### PR TITLE
fix: stop welcome markdown from replacing the open document

### DIFF
--- a/packages/frontend/src/api.ts
+++ b/packages/frontend/src/api.ts
@@ -4,7 +4,7 @@ export const fetchData = async <T>(
   signal?: AbortSignal,
 ): Promise<T | null> => {
   try {
-    const response = signal ? await fetch(url, { signal }) : await fetch(url);
+    const response = await fetch(url, { signal });
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);
     }
@@ -14,6 +14,9 @@ export const fetchData = async <T>(
       return await response.text() as T;
     }
   } catch (error) {
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      throw error;
+    }
     console.error(`Error fetching from ${url}:`, error);
     throw error;
   }

--- a/packages/frontend/src/api.ts
+++ b/packages/frontend/src/api.ts
@@ -1,6 +1,10 @@
-export const fetchData = async <T>(url: string, responseType: 'json' | 'text'): Promise<T | null> => {
+export const fetchData = async <T>(
+  url: string,
+  responseType: 'json' | 'text',
+  signal?: AbortSignal,
+): Promise<T | null> => {
   try {
-    const response = await fetch(url);
+    const response = signal ? await fetch(url, { signal }) : await fetch(url);
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);
     }

--- a/packages/frontend/src/components/Content/MarkdownContent/MarkdownContent.tsx
+++ b/packages/frontend/src/components/Content/MarkdownContent/MarkdownContent.tsx
@@ -35,20 +35,28 @@ const MarkdownContent: React.FC<MarkdownContentProps> = ({ scrollToId, onDirecto
   useEffect(() => {
     const request = dispatch(fetchContent(currentPath));
     return () => {
-      request?.abort?.();
+      request.abort();
     };
   }, [dispatch, currentPath]);
 
   useEffect(() => {
-    if (isGitRepository) {
-      dispatch(fetchDiff(currentPath));
+    if (!isGitRepository) {
+      return;
     }
+    const request = dispatch(fetchDiff(currentPath));
+    return () => {
+      request.abort();
+    };
   }, [dispatch, currentPath, isGitRepository]);
 
   useEffect(() => {
-    if (viewMode === 'diff-prev') {
-      dispatch(fetchDiffPrev(currentPath));
+    if (viewMode !== 'diff-prev') {
+      return;
     }
+    const request = dispatch(fetchDiffPrev(currentPath));
+    return () => {
+      request.abort();
+    };
   }, [dispatch, currentPath, viewMode]);
 
   useEffect(() => {

--- a/packages/frontend/src/components/Content/MarkdownContent/MarkdownContent.tsx
+++ b/packages/frontend/src/components/Content/MarkdownContent/MarkdownContent.tsx
@@ -33,7 +33,10 @@ const MarkdownContent: React.FC<MarkdownContentProps> = ({ scrollToId, onDirecto
   const loading = contentLoading || fileTreeLoading;
 
   useEffect(() => {
-    dispatch(fetchContent(currentPath));
+    const request = dispatch(fetchContent(currentPath));
+    return () => {
+      request?.abort?.();
+    };
   }, [dispatch, currentPath]);
 
   useEffect(() => {

--- a/packages/frontend/src/components/RightPane/Outline.tsx
+++ b/packages/frontend/src/components/RightPane/Outline.tsx
@@ -21,7 +21,10 @@ const Outline: React.FC<OutlineProps> = ({ filePath, onItemClick, isOpen, onTogg
   const { outline, loading, error } = useSelector((state: RootState) => state.outline);
 
   useEffect(() => {
-    dispatch(fetchOutline(filePath));
+    const request = dispatch(fetchOutline(filePath));
+    return () => {
+      request?.abort?.();
+    };
   }, [dispatch, filePath]);
 
   const handleItemClickWithClose = useCallback((id: string) => {

--- a/packages/frontend/src/components/RightPane/Outline.tsx
+++ b/packages/frontend/src/components/RightPane/Outline.tsx
@@ -23,7 +23,7 @@ const Outline: React.FC<OutlineProps> = ({ filePath, onItemClick, isOpen, onTogg
   useEffect(() => {
     const request = dispatch(fetchOutline(filePath));
     return () => {
-      request?.abort?.();
+      request.abort();
     };
   }, [dispatch, filePath]);
 

--- a/packages/frontend/src/store/isStaleRequest.ts
+++ b/packages/frontend/src/store/isStaleRequest.ts
@@ -1,0 +1,6 @@
+export const isStaleRequest = (
+  state: { latestRequestId: string | null },
+  action: { meta: { requestId: string; aborted?: boolean } },
+): boolean => (
+  state.latestRequestId !== action.meta.requestId || Boolean(action.meta.aborted)
+);

--- a/packages/frontend/src/store/slices/contentSlice.ts
+++ b/packages/frontend/src/store/slices/contentSlice.ts
@@ -1,6 +1,6 @@
-
 import { createSlice, createAsyncThunk, PayloadAction } from '@reduxjs/toolkit';
 import { fetchData } from '../../api';
+import { isStaleRequest } from '../isStaleRequest';
 
 interface ContentState {
   content: string;
@@ -21,7 +21,7 @@ const initialState: ContentState = {
 const encodePath = (path: string): string =>
   path.split('/').map(encodeURIComponent).join('/');
 
-export const markdownApiUrl = (path: string | null): string => (
+const markdownApiUrl = (path: string | null): string => (
   path
     ? `/api/markdown/${encodePath(path)}`
     : '/api/markdown/mdts-welcome-markdown.md'
@@ -53,14 +53,14 @@ const contentSlice = createSlice({
         state.error = null;
       })
       .addCase(fetchContent.fulfilled, (state, action) => {
-        if (state.latestRequestId !== action.meta.requestId) {
+        if (isStaleRequest(state, action)) {
           return;
         }
         state.loading = false;
         state.content = action.payload;
       })
       .addCase(fetchContent.rejected, (state, action) => {
-        if (state.latestRequestId !== action.meta.requestId || action.meta.aborted) {
+        if (isStaleRequest(state, action)) {
           return;
         }
         state.loading = false;

--- a/packages/frontend/src/store/slices/contentSlice.ts
+++ b/packages/frontend/src/store/slices/contentSlice.ts
@@ -7,6 +7,7 @@ interface ContentState {
   loading: boolean;
   error: string | null;
   scrollPosition: number;
+  latestRequestId: string | null;
 }
 
 const initialState: ContentState = {
@@ -14,13 +15,22 @@ const initialState: ContentState = {
   loading: true,
   error: null,
   scrollPosition: 0,
+  latestRequestId: null,
 };
+
+const encodePath = (path: string): string =>
+  path.split('/').map(encodeURIComponent).join('/');
+
+export const markdownApiUrl = (path: string | null): string => (
+  path
+    ? `/api/markdown/${encodePath(path)}`
+    : '/api/markdown/mdts-welcome-markdown.md'
+);
 
 export const fetchContent = createAsyncThunk(
   'content/fetchContent',
-  async (path: string | null) => {
-    const url = path ? `/api/markdown/${path}` : '/api/markdown/mdts-welcome-markdown.md';
-    const data = await fetchData<string>(url, 'text');
+  async (path: string | null, { signal }) => {
+    const data = await fetchData<string>(markdownApiUrl(path), 'text', signal);
     return data || '';
   }
 );
@@ -35,17 +45,24 @@ const contentSlice = createSlice({
   },
   extraReducers: (builder) => {
     builder
-      .addCase(fetchContent.pending, (state) => {
+      .addCase(fetchContent.pending, (state, action) => {
+        state.latestRequestId = action.meta.requestId;
         if (!state.content) {
           state.loading = true;
         }
         state.error = null;
       })
       .addCase(fetchContent.fulfilled, (state, action) => {
+        if (state.latestRequestId !== action.meta.requestId) {
+          return;
+        }
         state.loading = false;
         state.content = action.payload;
       })
       .addCase(fetchContent.rejected, (state, action) => {
+        if (state.latestRequestId !== action.meta.requestId || action.meta.aborted) {
+          return;
+        }
         state.loading = false;
         state.error = action.error.message || 'Failed to fetch content';
       });

--- a/packages/frontend/src/store/slices/diffSlice.ts
+++ b/packages/frontend/src/store/slices/diffSlice.ts
@@ -1,5 +1,6 @@
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 import { fetchData } from '../../api';
+import { isStaleRequest } from '../isStaleRequest';
 
 interface DiffState {
   diff: string;
@@ -8,6 +9,8 @@ interface DiffState {
   diffPrevLoading: boolean;
   diffError: string | null;
   diffPrevError: string | null;
+  latestDiffRequestId: string | null;
+  latestDiffPrevRequestId: string | null;
 }
 
 const initialState: DiffState = {
@@ -17,6 +20,8 @@ const initialState: DiffState = {
   diffPrevLoading: false,
   diffError: null,
   diffPrevError: null,
+  latestDiffRequestId: null,
+  latestDiffPrevRequestId: null,
 };
 
 const encodePath = (path: string): string =>
@@ -24,18 +29,18 @@ const encodePath = (path: string): string =>
 
 export const fetchDiff = createAsyncThunk(
   'diff/fetchDiff',
-  async (path: string | null) => {
+  async (path: string | null, { signal }) => {
     if (!path) return '';
-    const data = await fetchData<string>(`/api/diff/${encodePath(path)}`, 'text');
+    const data = await fetchData<string>(`/api/diff/${encodePath(path)}`, 'text', signal);
     return data || '';
   }
 );
 
 export const fetchDiffPrev = createAsyncThunk(
   'diff/fetchDiffPrev',
-  async (path: string | null) => {
+  async (path: string | null, { signal }) => {
     if (!path) return '';
-    const data = await fetchData<string>(`/api/diff-prev/${encodePath(path)}`, 'text');
+    const data = await fetchData<string>(`/api/diff-prev/${encodePath(path)}`, 'text', signal);
     return data || '';
   }
 );
@@ -46,28 +51,42 @@ const diffSlice = createSlice({
   reducers: {},
   extraReducers: (builder) => {
     builder
-      .addCase(fetchDiff.pending, (state) => {
+      .addCase(fetchDiff.pending, (state, action) => {
+        state.latestDiffRequestId = action.meta.requestId;
         state.diffLoading = true;
         state.diffError = null;
       })
       .addCase(fetchDiff.fulfilled, (state, action) => {
+        if (isStaleRequest({ latestRequestId: state.latestDiffRequestId }, action)) {
+          return;
+        }
         state.diffLoading = false;
         state.diff = action.payload;
       })
       .addCase(fetchDiff.rejected, (state, action) => {
+        if (isStaleRequest({ latestRequestId: state.latestDiffRequestId }, action)) {
+          return;
+        }
         state.diffLoading = false;
         state.diff = '';
         state.diffError = action.error.message || 'Failed to fetch diff';
       })
-      .addCase(fetchDiffPrev.pending, (state) => {
+      .addCase(fetchDiffPrev.pending, (state, action) => {
+        state.latestDiffPrevRequestId = action.meta.requestId;
         state.diffPrevLoading = true;
         state.diffPrevError = null;
       })
       .addCase(fetchDiffPrev.fulfilled, (state, action) => {
+        if (isStaleRequest({ latestRequestId: state.latestDiffPrevRequestId }, action)) {
+          return;
+        }
         state.diffPrevLoading = false;
         state.diffPrev = action.payload;
       })
       .addCase(fetchDiffPrev.rejected, (state, action) => {
+        if (isStaleRequest({ latestRequestId: state.latestDiffPrevRequestId }, action)) {
+          return;
+        }
         state.diffPrevLoading = false;
         state.diffPrev = '';
         state.diffPrevError = action.error.message || 'Failed to fetch previous diff';

--- a/packages/frontend/src/store/slices/historySlice.ts
+++ b/packages/frontend/src/store/slices/historySlice.ts
@@ -1,26 +1,36 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { AppDispatch } from '../store';
+import type { AppDispatch } from '../store';
 
 interface HistoryState {
   currentPath: string | null;
   isDirectory: boolean;
 }
 
+const decodePath = (path: string): string => {
+  try {
+    return decodeURIComponent(path);
+  } catch {
+    return path;
+  }
+};
+
 export const parseHistoryFromPathname = (pathname: string): HistoryState => {
-  const path = pathname.substring(1);
-  if (path === '') {
+  const rawPath = pathname.substring(1);
+  if (rawPath === '') {
     return { currentPath: null, isDirectory: false };
   }
 
+  const path = decodePath(rawPath);
   const fileExtensions = ['.md', '.markdown'];
   const isFile = fileExtensions.some((ext) => path.toLowerCase().endsWith(ext));
 
-  return { currentPath: decodeURIComponent(path), isDirectory: !isFile };
+  return { currentPath: path, isDirectory: !isFile };
 };
 
-const initialState: HistoryState = typeof window === 'undefined'
-  ? { currentPath: null, isDirectory: false }
-  : parseHistoryFromPathname(window.location.pathname);
+const initialState: HistoryState = {
+  currentPath: null,
+  isDirectory: false,
+};
 
 const historySlice = createSlice({
   name: 'history',

--- a/packages/frontend/src/store/slices/historySlice.ts
+++ b/packages/frontend/src/store/slices/historySlice.ts
@@ -6,10 +6,21 @@ interface HistoryState {
   isDirectory: boolean;
 }
 
-const initialState: HistoryState = {
-  currentPath: null,
-  isDirectory: false,
+export const parseHistoryFromPathname = (pathname: string): HistoryState => {
+  const path = pathname.substring(1);
+  if (path === '') {
+    return { currentPath: null, isDirectory: false };
+  }
+
+  const fileExtensions = ['.md', '.markdown'];
+  const isFile = fileExtensions.some((ext) => path.toLowerCase().endsWith(ext));
+
+  return { currentPath: decodeURIComponent(path), isDirectory: !isFile };
 };
+
+const initialState: HistoryState = typeof window === 'undefined'
+  ? { currentPath: null, isDirectory: false }
+  : parseHistoryFromPathname(window.location.pathname);
 
 const historySlice = createSlice({
   name: 'history',
@@ -28,20 +39,8 @@ const historySlice = createSlice({
 export const { setHistory } = historySlice.actions;
 
 export const updateHistoryFromLocation = (pathname: string) => (dispatch: AppDispatch): void => {
-  const getPathFromUrl = () => {
-    const path = pathname.substring(1);
-    if (path === '') return { path: null, isDirectory: false };
-
-    const fileExtensions = ['.md', '.markdown'];
-    const isFile = fileExtensions.some((ext) =>
-      path.toLowerCase().endsWith(ext)
-    );
-
-    return { path: decodeURIComponent(path), isDirectory: !isFile };
-  };
-
-  const { path, isDirectory } = getPathFromUrl();
-  dispatch(setHistory({ path, isDirectory }));
+  const { currentPath, isDirectory } = parseHistoryFromPathname(pathname);
+  dispatch(setHistory({ path: currentPath, isDirectory }));
 };
 
 export default historySlice.reducer;

--- a/packages/frontend/src/store/slices/outlineSlice.ts
+++ b/packages/frontend/src/store/slices/outlineSlice.ts
@@ -1,5 +1,6 @@
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 import { fetchData } from '../../api';
+import { isStaleRequest } from '../isStaleRequest';
 
 export type OutlineItem = {
   id: string;
@@ -44,14 +45,14 @@ const outlineSlice = createSlice({
         state.error = null;
       })
       .addCase(fetchOutline.fulfilled, (state, action) => {
-        if (state.latestRequestId !== action.meta.requestId) {
+        if (isStaleRequest(state, action)) {
           return;
         }
         state.loading = false;
         state.outline = action.payload;
       })
       .addCase(fetchOutline.rejected, (state, action) => {
-        if (state.latestRequestId !== action.meta.requestId || action.meta.aborted) {
+        if (isStaleRequest(state, action)) {
           return;
         }
         state.loading = false;

--- a/packages/frontend/src/store/slices/outlineSlice.ts
+++ b/packages/frontend/src/store/slices/outlineSlice.ts
@@ -11,21 +11,23 @@ interface OutlineState {
   outline: OutlineItem[];
   loading: boolean;
   error: string | null;
+  latestRequestId: string | null;
 }
 
 const initialState: OutlineState = {
   outline: [],
   loading: true,
   error: null,
+  latestRequestId: null,
 };
 
 export const fetchOutline = createAsyncThunk(
   'outline/fetchOutline',
-  async (path: string | null) => {
+  async (path: string | null, { signal }) => {
     const url = path
       ? `/api/outline?filePath=${encodeURIComponent(path)}`
       : '/api/outline?filePath=mdts-welcome-markdown.md';
-    const data = await fetchData<OutlineItem[]>(url, 'json');
+    const data = await fetchData<OutlineItem[]>(url, 'json', signal);
     return data || [];
   }
 );
@@ -36,15 +38,22 @@ const outlineSlice = createSlice({
   reducers: {},
   extraReducers: (builder) => {
     builder
-      .addCase(fetchOutline.pending, (state) => {
+      .addCase(fetchOutline.pending, (state, action) => {
+        state.latestRequestId = action.meta.requestId;
         state.loading = true;
         state.error = null;
       })
       .addCase(fetchOutline.fulfilled, (state, action) => {
+        if (state.latestRequestId !== action.meta.requestId) {
+          return;
+        }
         state.loading = false;
         state.outline = action.payload;
       })
       .addCase(fetchOutline.rejected, (state, action) => {
+        if (state.latestRequestId !== action.meta.requestId || action.meta.aborted) {
+          return;
+        }
         state.loading = false;
         state.error = action.error.message || 'Failed to fetch outline';
       });

--- a/packages/frontend/src/store/store.ts
+++ b/packages/frontend/src/store/store.ts
@@ -4,7 +4,7 @@ import diffReducer from './slices/diffSlice';
 import fileTreeReducer from './slices/fileTreeSlice';
 import outlineReducer from './slices/outlineSlice';
 import appSettingReducer, { saveAppSetting } from './slices/appSettingSlice';
-import historyReducer from './slices/historySlice';
+import historyReducer, { parseHistoryFromPathname } from './slices/historySlice';
 import configReducer from './slices/configSlice';
 import plantUMLReducer from './slices/plantUMLSlice';
 
@@ -60,7 +60,10 @@ export const store = configureStore({
     config: configReducer,
     plantUML: plantUMLReducer,
   },
-  preloadedState: loadState(),
+  preloadedState: {
+    ...loadState(),
+    history: parseHistoryFromPathname(window.location.pathname),
+  },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware().prepend(listenerMiddleware.middleware),
 });

--- a/packages/frontend/test/unit/App.behavior.test.tsx
+++ b/packages/frontend/test/unit/App.behavior.test.tsx
@@ -56,6 +56,7 @@ jest.mock('../../src/store/slices/fileTreeSlice', () => ({
 }));
 
 jest.mock('../../src/store/slices/historySlice', () => ({
+  ...jest.requireActual('../../src/store/slices/historySlice'),
   updateHistoryFromLocation: jest.fn((pathname: string) => ({
     type: 'history/updateHistoryFromLocation/mock',
     payload: pathname,

--- a/packages/frontend/test/unit/api.test.ts
+++ b/packages/frontend/test/unit/api.test.ts
@@ -29,7 +29,7 @@ describe('fetchData', () => {
     mockFetch.mockResolvedValueOnce(createResponse({ json: payload }));
 
     await expect(fetchData<typeof payload>('/api/config', 'json')).resolves.toEqual(payload);
-    expect(mockFetch).toHaveBeenCalledWith('/api/config');
+    expect(mockFetch).toHaveBeenCalledWith('/api/config', { signal: undefined });
   });
 
   it('returns text when responseType is text', async () => {
@@ -58,5 +58,15 @@ describe('fetchData', () => {
 
     await expect(fetchData('/api/config', 'json')).rejects.toThrow(error);
     expect(consoleErrorSpy).toHaveBeenCalledWith('Error fetching from /api/config:', error);
+  });
+
+  it('rethrows abort errors without logging', async () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const abortError = new DOMException('Aborted', 'AbortError');
+
+    mockFetch.mockRejectedValueOnce(abortError);
+
+    await expect(fetchData('/api/config', 'json')).rejects.toBe(abortError);
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/frontend/test/unit/components/Content/MarkdownContent/MarkdownContent.test.tsx
+++ b/packages/frontend/test/unit/components/Content/MarkdownContent/MarkdownContent.test.tsx
@@ -117,6 +117,47 @@ describe('MarkdownContent', () => {
     ]);
   });
 
+  test('does not fetch diffs when the directory is not a git repository', async () => {
+    store = mockStore({
+      content: {
+        content: '# Test Markdown',
+        loading: false,
+        error: null,
+      },
+      diff: defaultDiffState,
+      fileTree: {
+        loading: false,
+        isGitRepository: false,
+      },
+      history: {
+        currentPath: '/path/to/test.md',
+        isDirectory: false,
+      },
+      appSetting: {
+        contentMode: 'compact',
+      },
+      config: {
+        fontFamily: 'Roboto',
+        fontFamilyMonospace: 'monospace',
+        fontSize: 14,
+      },
+    });
+
+    await act(async () => {
+      render(
+        <Provider store={store}>
+          <BrowserRouter>
+            <MarkdownContent scrollToId={null} />
+          </BrowserRouter>
+        </Provider>
+      );
+    });
+
+    expect(store.getActions()).toEqual([
+      { type: 'content/fetchContent', payload: '/path/to/test.md' },
+    ]);
+  });
+
   test('renders file content when a file is selected', async () => {
     store = mockStore({
       content: {

--- a/packages/frontend/test/unit/components/Content/MarkdownContent/MarkdownContent.test.tsx
+++ b/packages/frontend/test/unit/components/Content/MarkdownContent/MarkdownContent.test.tsx
@@ -8,22 +8,30 @@ import MarkdownContent from '../../../../../src/components/Content/MarkdownConte
 
 const mockStore = configureStore([thunk]);
 
-jest.mock('../../../../../src/store/slices/contentSlice', () => ({
-  ...jest.requireActual('../../../../../src/store/slices/contentSlice'),
-  fetchContent: jest.fn((path) => (dispatch) => {
-    dispatch({ type: 'content/fetchContent', payload: path });
-  }),
-}));
+jest.mock('../../../../../src/store/slices/contentSlice', () => {
+  const createAbortableThunk = (type: string) => (path: string | null) => (dispatch: (action: unknown) => void) => {
+    dispatch({ type, payload: path });
+    return { abort: jest.fn() };
+  };
 
-jest.mock('../../../../../src/store/slices/diffSlice', () => ({
-  ...jest.requireActual('../../../../../src/store/slices/diffSlice'),
-  fetchDiff: jest.fn((path) => (dispatch) => {
-    dispatch({ type: 'diff/fetchDiff', payload: path });
-  }),
-  fetchDiffPrev: jest.fn((path) => (dispatch) => {
-    dispatch({ type: 'diff/fetchDiffPrev', payload: path });
-  }),
-}));
+  return {
+    ...jest.requireActual('../../../../../src/store/slices/contentSlice'),
+    fetchContent: jest.fn(createAbortableThunk('content/fetchContent')),
+  };
+});
+
+jest.mock('../../../../../src/store/slices/diffSlice', () => {
+  const createAbortableThunk = (type: string) => (path: string | null) => (dispatch: (action: unknown) => void) => {
+    dispatch({ type, payload: path });
+    return { abort: jest.fn() };
+  };
+
+  return {
+    ...jest.requireActual('../../../../../src/store/slices/diffSlice'),
+    fetchDiff: jest.fn(createAbortableThunk('diff/fetchDiff')),
+    fetchDiffPrev: jest.fn(createAbortableThunk('diff/fetchDiffPrev')),
+  };
+});
 
 const defaultDiffState = {
   diff: '',

--- a/packages/frontend/test/unit/components/RightPane/Outline.test.tsx
+++ b/packages/frontend/test/unit/components/RightPane/Outline.test.tsx
@@ -22,6 +22,12 @@ jest.mock('../../../../src/hooks/useIsMobile', () => ({
 describe('Outline', () => {
   let store;
 
+  const createStore = (state: { outline: { outline: unknown[]; loading: boolean; error: string | null } }) => {
+    const nextStore = mockStore(state);
+    nextStore.dispatch = jest.fn(() => ({ abort: jest.fn() }));
+    return nextStore;
+  };
+
   const renderOutline = (props = {}) => render(
     <Provider store={store}>
       <Outline filePath="/test.md" onItemClick={jest.fn()} isOpen={true} onToggle={jest.fn()} {...props} />
@@ -30,14 +36,13 @@ describe('Outline', () => {
 
   beforeEach(() => {
     (useIsMobile as jest.Mock).mockReturnValue(false);
-    store = mockStore({
+    store = createStore({
       outline: {
         outline: [{ id: 'title', content: 'Title', level: 1 }],
         loading: false,
         error: null,
       },
     });
-    store.dispatch = jest.fn();
   });
 
   test('renders correctly', async () => {
@@ -72,7 +77,7 @@ describe('Outline', () => {
   });
 
   test('displays loading spinner when outline is loading', () => {
-    store = mockStore({
+    store = createStore({
       outline: {
         outline: [],
         loading: true,
@@ -86,7 +91,7 @@ describe('Outline', () => {
   });
 
   test('displays error message when there is an error', () => {
-    store = mockStore({
+    store = createStore({
       outline: {
         outline: [],
         loading: false,

--- a/packages/frontend/test/unit/store/contentSlice.test.ts
+++ b/packages/frontend/test/unit/store/contentSlice.test.ts
@@ -1,10 +1,23 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { fetchData } from '../../../src/api';
 import contentReducer, { fetchContent, setScrollPosition } from '../../../src/store/slices/contentSlice';
 
 jest.mock('../../../src/api', () => ({
   fetchData: jest.fn(),
 }));
 
+const mockFetchData = fetchData as jest.MockedFunction<typeof fetchData>;
+
+const aborted = <T extends { meta: { aborted?: boolean } }>(action: T): T => ({
+  ...action,
+  meta: { ...action.meta, aborted: true },
+});
+
 describe('contentSlice', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   const initialState = {
     content: '',
     loading: true,
@@ -86,6 +99,59 @@ describe('contentSlice', () => {
       previousState,
       fetchContent.fulfilled('# Welcome to mdts! 🚀', 'older-request', null),
     )).toEqual(previousState);
+  });
+
+  it('should ignore aborted fetchContent.rejected results', () => {
+    const previousState = {
+      ...initialState,
+      content: 'current file',
+      loading: false,
+      latestRequestId: 'requestId',
+    };
+    expect(contentReducer(
+      previousState,
+      aborted(fetchContent.rejected(new Error('Aborted'), 'requestId', null)),
+    )).toEqual(previousState);
+  });
+
+  it('fetches the selected file instead of welcome markdown', async () => {
+    mockFetchData.mockResolvedValue('# selected file');
+    const store = configureStore({ reducer: { content: contentReducer } });
+
+    await store.dispatch(fetchContent('audit-review.md'));
+
+    expect(mockFetchData).toHaveBeenCalledWith(
+      '/api/markdown/audit-review.md',
+      'text',
+      expect.any(AbortSignal),
+    );
+    expect(store.getState().content.content).toBe('# selected file');
+  });
+
+  it('encodes markdown path segments when fetching content', async () => {
+    mockFetchData.mockResolvedValue('# encoded');
+    const store = configureStore({ reducer: { content: contentReducer } });
+
+    await store.dispatch(fetchContent('docs/my file.md'));
+
+    expect(mockFetchData).toHaveBeenCalledWith(
+      '/api/markdown/docs/my%20file.md',
+      'text',
+      expect.any(AbortSignal),
+    );
+  });
+
+  it('fetches welcome markdown when no file is selected', async () => {
+    mockFetchData.mockResolvedValue('# Welcome');
+    const store = configureStore({ reducer: { content: contentReducer } });
+
+    await store.dispatch(fetchContent(null));
+
+    expect(mockFetchData).toHaveBeenCalledWith(
+      '/api/markdown/mdts-welcome-markdown.md',
+      'text',
+      expect.any(AbortSignal),
+    );
   });
 
   it('should handle setScrollPosition', () => {

--- a/packages/frontend/test/unit/store/contentSlice.test.ts
+++ b/packages/frontend/test/unit/store/contentSlice.test.ts
@@ -10,6 +10,7 @@ describe('contentSlice', () => {
     loading: true,
     error: null,
     scrollPosition: 0,
+    latestRequestId: null,
   };
 
   it('should return the initial state', () => {
@@ -23,6 +24,7 @@ describe('contentSlice', () => {
         ...initialState,
         loading: true,
         content: '',
+        latestRequestId: 'requestId',
       });
     });
 
@@ -36,6 +38,7 @@ describe('contentSlice', () => {
         ...initialState,
         loading: false,
         content: 'old content',
+        latestRequestId: 'requestId',
       });
     });
   });
@@ -45,11 +48,13 @@ describe('contentSlice', () => {
       ...initialState,
       content: 'old content',
       loading: true,
+      latestRequestId: 'requestId',
     };
     expect(contentReducer(previousState, fetchContent.fulfilled('new content', 'requestId', null))).toEqual({
       ...initialState,
       content: 'new content',
       loading: false,
+      latestRequestId: 'requestId',
     });
   });
 
@@ -58,6 +63,7 @@ describe('contentSlice', () => {
       ...initialState,
       content: 'old content',
       loading: true,
+      latestRequestId: 'requestId',
     };
     const error = new Error('Failed to fetch');
     expect(contentReducer(previousState, fetchContent.rejected(error, 'requestId', null))).toEqual({
@@ -65,7 +71,21 @@ describe('contentSlice', () => {
       content: 'old content',
       loading: false,
       error: 'Failed to fetch',
+      latestRequestId: 'requestId',
     });
+  });
+
+  it('should ignore stale fetchContent.fulfilled results', () => {
+    const previousState = {
+      ...initialState,
+      content: 'current file',
+      loading: false,
+      latestRequestId: 'newer-request',
+    };
+    expect(contentReducer(
+      previousState,
+      fetchContent.fulfilled('# Welcome to mdts! 🚀', 'older-request', null),
+    )).toEqual(previousState);
   });
 
   it('should handle setScrollPosition', () => {

--- a/packages/frontend/test/unit/store/diffSlice.test.ts
+++ b/packages/frontend/test/unit/store/diffSlice.test.ts
@@ -8,6 +8,11 @@ jest.mock('../../../src/api', () => ({
 
 const mockFetchData = fetchData as jest.MockedFunction<typeof fetchData>;
 
+const aborted = <T extends { meta: { aborted?: boolean } }>(action: T): T => ({
+  ...action,
+  meta: { ...action.meta, aborted: true },
+});
+
 describe('diffSlice', () => {
   const initialState = {
     diff: '',
@@ -16,6 +21,8 @@ describe('diffSlice', () => {
     diffPrevLoading: false,
     diffError: null,
     diffPrevError: null,
+    latestDiffRequestId: null,
+    latestDiffPrevRequestId: null,
   };
 
   const createTestStore = () =>
@@ -43,14 +50,19 @@ describe('diffSlice', () => {
     });
 
     it('should set diff content on fulfilled', () => {
-      const prev = { ...initialState, diffLoading: true };
+      const prev = { ...initialState, diffLoading: true, latestDiffRequestId: 'requestId' };
       const state = diffReducer(prev, fetchDiff.fulfilled('+added line', 'requestId', 'test.md'));
       expect(state.diffLoading).toBe(false);
       expect(state.diff).toBe('+added line');
     });
 
     it('should set error and clear diff on rejected', () => {
-      const prev = { ...initialState, diffLoading: true, diff: 'stale diff' };
+      const prev = {
+        ...initialState,
+        diffLoading: true,
+        diff: 'stale diff',
+        latestDiffRequestId: 'requestId',
+      };
       const error = new Error('Network error');
       const state = diffReducer(prev, fetchDiff.rejected(error, 'requestId', 'test.md'));
       expect(state.diffLoading).toBe(false);
@@ -59,9 +71,33 @@ describe('diffSlice', () => {
     });
 
     it('should set error message when error has no custom message', () => {
-      const prev = { ...initialState, diffLoading: true };
+      const prev = { ...initialState, diffLoading: true, latestDiffRequestId: 'requestId' };
       const state = diffReducer(prev, fetchDiff.rejected(null, 'requestId', 'test.md'));
       expect(state.diffError).toBeTruthy();
+    });
+
+    it('should ignore stale fetchDiff.fulfilled results', () => {
+      const prev = {
+        ...initialState,
+        diff: 'current diff',
+        latestDiffRequestId: 'newer-request',
+      };
+      expect(diffReducer(
+        prev,
+        fetchDiff.fulfilled('+stale', 'older-request', 'old.md'),
+      )).toEqual(prev);
+    });
+
+    it('should ignore aborted fetchDiff.rejected results', () => {
+      const prev = {
+        ...initialState,
+        diff: 'current diff',
+        latestDiffRequestId: 'requestId',
+      };
+      expect(diffReducer(
+        prev,
+        aborted(fetchDiff.rejected(new Error('Aborted'), 'requestId', 'test.md')),
+      )).toEqual(prev);
     });
 
     it('should return empty string when path is null', async () => {
@@ -75,7 +111,11 @@ describe('diffSlice', () => {
       mockFetchData.mockResolvedValue('+added');
       const store = createTestStore();
       await store.dispatch(fetchDiff('docs/my file.md'));
-      expect(mockFetchData).toHaveBeenCalledWith('/api/diff/docs/my%20file.md', 'text');
+      expect(mockFetchData).toHaveBeenCalledWith(
+        '/api/diff/docs/my%20file.md',
+        'text',
+        expect.any(AbortSignal),
+      );
       expect(store.getState().diff.diff).toBe('+added');
     });
 
@@ -101,14 +141,19 @@ describe('diffSlice', () => {
     });
 
     it('should set diffPrev content on fulfilled', () => {
-      const prev = { ...initialState, diffPrevLoading: true };
+      const prev = { ...initialState, diffPrevLoading: true, latestDiffPrevRequestId: 'requestId' };
       const state = diffReducer(prev, fetchDiffPrev.fulfilled('-old\n+new', 'requestId', 'test.md'));
       expect(state.diffPrevLoading).toBe(false);
       expect(state.diffPrev).toBe('-old\n+new');
     });
 
     it('should set error and clear diffPrev on rejected', () => {
-      const prev = { ...initialState, diffPrevLoading: true, diffPrev: 'stale diff' };
+      const prev = {
+        ...initialState,
+        diffPrevLoading: true,
+        diffPrev: 'stale diff',
+        latestDiffPrevRequestId: 'requestId',
+      };
       const error = new Error('Server error');
       const state = diffReducer(prev, fetchDiffPrev.rejected(error, 'requestId', 'test.md'));
       expect(state.diffPrevLoading).toBe(false);
@@ -117,9 +162,33 @@ describe('diffSlice', () => {
     });
 
     it('should set error message when error has no custom message', () => {
-      const prev = { ...initialState, diffPrevLoading: true };
+      const prev = { ...initialState, diffPrevLoading: true, latestDiffPrevRequestId: 'requestId' };
       const state = diffReducer(prev, fetchDiffPrev.rejected(null, 'requestId', 'test.md'));
       expect(state.diffPrevError).toBeTruthy();
+    });
+
+    it('should ignore stale fetchDiffPrev.fulfilled results', () => {
+      const prev = {
+        ...initialState,
+        diffPrev: 'current prev',
+        latestDiffPrevRequestId: 'newer-request',
+      };
+      expect(diffReducer(
+        prev,
+        fetchDiffPrev.fulfilled('+stale', 'older-request', 'old.md'),
+      )).toEqual(prev);
+    });
+
+    it('should ignore aborted fetchDiffPrev.rejected results', () => {
+      const prev = {
+        ...initialState,
+        diffPrev: 'current prev',
+        latestDiffPrevRequestId: 'requestId',
+      };
+      expect(diffReducer(
+        prev,
+        aborted(fetchDiffPrev.rejected(new Error('Aborted'), 'requestId', 'test.md')),
+      )).toEqual(prev);
     });
 
     it('should return empty string when path is null', async () => {
@@ -133,7 +202,11 @@ describe('diffSlice', () => {
       mockFetchData.mockResolvedValue('-old\n+new');
       const store = createTestStore();
       await store.dispatch(fetchDiffPrev('docs/my file.md'));
-      expect(mockFetchData).toHaveBeenCalledWith('/api/diff-prev/docs/my%20file.md', 'text');
+      expect(mockFetchData).toHaveBeenCalledWith(
+        '/api/diff-prev/docs/my%20file.md',
+        'text',
+        expect.any(AbortSignal),
+      );
       expect(store.getState().diff.diffPrev).toBe('-old\n+new');
     });
 

--- a/packages/frontend/test/unit/store/historySlice.test.ts
+++ b/packages/frontend/test/unit/store/historySlice.test.ts
@@ -1,5 +1,9 @@
 import { configureStore } from '@reduxjs/toolkit';
-import historyReducer, { setHistory, updateHistoryFromLocation } from '../../../src/store/slices/historySlice';
+import historyReducer, {
+  parseHistoryFromPathname,
+  setHistory,
+  updateHistoryFromLocation,
+} from '../../../src/store/slices/historySlice';
 
 describe('historySlice', () => {
   let store: ReturnType<typeof configureStore>;
@@ -15,6 +19,54 @@ describe('historySlice', () => {
   it('should return the initial state', () => {
     expect(store.getState().history.currentPath).toBeNull();
     expect(store.getState().history.isDirectory).toBe(false);
+  });
+
+  describe('parseHistoryFromPathname', () => {
+    it('returns an empty history for the root path', () => {
+      expect(parseHistoryFromPathname('/')).toEqual({
+        currentPath: null,
+        isDirectory: false,
+      });
+    });
+
+    it('treats a markdown file as a file', () => {
+      expect(parseHistoryFromPathname('/a.md')).toEqual({
+        currentPath: 'a.md',
+        isDirectory: false,
+      });
+    });
+
+    it('treats a path without a markdown extension as a directory', () => {
+      expect(parseHistoryFromPathname('/dir')).toEqual({
+        currentPath: 'dir',
+        isDirectory: true,
+      });
+    });
+
+    it('decodes encoded path segments', () => {
+      expect(parseHistoryFromPathname('/docs/my%20file.md')).toEqual({
+        currentPath: 'docs/my file.md',
+        isDirectory: false,
+      });
+    });
+
+    it('classifies an encoded markdown extension as a file', () => {
+      expect(parseHistoryFromPathname('/docs/readme%2Emd')).toEqual({
+        currentPath: 'docs/readme.md',
+        isDirectory: false,
+      });
+    });
+
+    it('falls back to the raw path when decoding fails', () => {
+      expect(parseHistoryFromPathname('/%')).toEqual({
+        currentPath: '%',
+        isDirectory: true,
+      });
+      expect(parseHistoryFromPathname('/%E0%A4%A')).toEqual({
+        currentPath: '%E0%A4%A',
+        isDirectory: true,
+      });
+    });
   });
 
   it('should handle setHistory', () => {

--- a/packages/frontend/test/unit/store/isStaleRequest.test.ts
+++ b/packages/frontend/test/unit/store/isStaleRequest.test.ts
@@ -1,0 +1,24 @@
+import { isStaleRequest } from '../../../src/store/isStaleRequest';
+
+describe('isStaleRequest', () => {
+  it('returns false for the current request', () => {
+    expect(isStaleRequest(
+      { latestRequestId: 'requestId' },
+      { meta: { requestId: 'requestId' } },
+    )).toBe(false);
+  });
+
+  it('returns true when the request id no longer matches', () => {
+    expect(isStaleRequest(
+      { latestRequestId: 'newer-request' },
+      { meta: { requestId: 'older-request' } },
+    )).toBe(true);
+  });
+
+  it('returns true when the current request was aborted', () => {
+    expect(isStaleRequest(
+      { latestRequestId: 'requestId' },
+      { meta: { requestId: 'requestId', aborted: true } },
+    )).toBe(true);
+  });
+});

--- a/packages/frontend/test/unit/store/outlineSlice.test.ts
+++ b/packages/frontend/test/unit/store/outlineSlice.test.ts
@@ -10,6 +10,7 @@ describe('outlineSlice', () => {
       outline: [],
       loading: true,
       error: null,
+      latestRequestId: null,
     });
   });
 
@@ -23,6 +24,7 @@ describe('outlineSlice', () => {
       outline: [{ id: '1', content: 'old outline', level: 1 }],
       loading: true,
       error: null,
+      latestRequestId: 'requestId',
     });
   });
 
@@ -31,12 +33,14 @@ describe('outlineSlice', () => {
       outline: [{ id: '1', content: 'old outline', level: 1 }],
       loading: true,
       error: null,
+      latestRequestId: 'requestId',
     };
     const newOutline = [{ id: '2', content: 'new outline', level: 1 }];
     expect(outlineReducer(previousState, fetchOutline.fulfilled(newOutline, 'requestId', null))).toEqual({
       outline: newOutline,
       loading: false,
       error: null,
+      latestRequestId: 'requestId',
     });
   });
 
@@ -45,12 +49,14 @@ describe('outlineSlice', () => {
       outline: [{ id: '1', content: 'old outline', level: 1 }],
       loading: true,
       error: null,
+      latestRequestId: 'requestId',
     };
     const error = new Error('Failed to fetch');
     expect(outlineReducer(previousState, fetchOutline.rejected(error, 'requestId', null))).toEqual({
       outline: [{ id: '1', content: 'old outline', level: 1 }],
       loading: false,
       error: 'Failed to fetch',
+      latestRequestId: 'requestId',
     });
   });
 });

--- a/packages/frontend/test/unit/store/outlineSlice.test.ts
+++ b/packages/frontend/test/unit/store/outlineSlice.test.ts
@@ -4,6 +4,11 @@ jest.mock('../../../src/api', () => ({
   fetchData: jest.fn(),
 }));
 
+const aborted = <T extends { meta: { aborted?: boolean } }>(action: T): T => ({
+  ...action,
+  meta: { ...action.meta, aborted: true },
+});
+
 describe('outlineSlice', () => {
   it('should return the initial state', () => {
     expect(outlineReducer(undefined, { type: '' })).toEqual({
@@ -19,6 +24,7 @@ describe('outlineSlice', () => {
       outline: [{ id: '1', content: 'old outline', level: 1 }],
       loading: false,
       error: 'some error',
+      latestRequestId: null,
     };
     expect(outlineReducer(previousState, fetchOutline.pending('requestId', null))).toEqual({
       outline: [{ id: '1', content: 'old outline', level: 1 }],
@@ -58,5 +64,31 @@ describe('outlineSlice', () => {
       error: 'Failed to fetch',
       latestRequestId: 'requestId',
     });
+  });
+
+  it('should ignore stale fetchOutline.fulfilled results', () => {
+    const previousState = {
+      outline: [{ id: '1', content: 'current outline', level: 1 }],
+      loading: false,
+      error: null,
+      latestRequestId: 'newer-request',
+    };
+    expect(outlineReducer(
+      previousState,
+      fetchOutline.fulfilled([{ id: '2', content: 'stale outline', level: 1 }], 'older-request', null),
+    )).toEqual(previousState);
+  });
+
+  it('should ignore aborted fetchOutline.rejected results', () => {
+    const previousState = {
+      outline: [{ id: '1', content: 'current outline', level: 1 }],
+      loading: false,
+      error: null,
+      latestRequestId: 'requestId',
+    };
+    expect(outlineReducer(
+      previousState,
+      aborted(fetchOutline.rejected(new Error('Aborted'), 'requestId', null)),
+    )).toEqual(previousState);
   });
 });

--- a/packages/frontend/test/unit/store/store.test.ts
+++ b/packages/frontend/test/unit/store/store.test.ts
@@ -44,6 +44,18 @@ describe('store', () => {
     jest.restoreAllMocks();
     localStorage.clear();
     document.body.removeAttribute('data-theme');
+    window.history.replaceState({}, '', '/');
+  });
+
+  it('seeds history from a deep-link URL so the first content fetch is not welcome', async () => {
+    window.history.replaceState({}, '', '/audit-review.md');
+
+    const { store } = await importStoreModule();
+
+    expect(store.getState().history).toEqual({
+      currentPath: 'audit-review.md',
+      isDirectory: false,
+    });
   });
 
   it('uses the default app setting when localStorage is empty', async () => {

--- a/packages/frontend/test/utils.ts
+++ b/packages/frontend/test/utils.ts
@@ -33,6 +33,8 @@ export const createMockStore = (
       content: '',
       loading: false,
       error: null,
+      scrollPosition: 0,
+      latestRequestId: null,
     },
     diff: {
       diff: '',
@@ -41,11 +43,14 @@ export const createMockStore = (
       diffPrevLoading: false,
       diffError: null,
       diffPrevError: null,
+      latestDiffRequestId: null,
+      latestDiffPrevRequestId: null,
     },
     outline: {
       outline: [],
       loading: false,
       error: null,
+      latestRequestId: null,
     },
     history: {
       currentPath: null,


### PR DESCRIPTION
## Summary
- Deep links now initialize `currentPath` from the URL, so opening a file no longer starts by fetching the welcome page
- Ignore stale content and outline responses so a late welcome request cannot overwrite the selected document
- Abort in-flight fetches when the path changes, and encode markdown API path segments

## Test plan
- [ ] Open `http://host:port/some-file.md` directly and confirm preview shows that file, not Welcome to mdts
- [ ] Confirm the outline headings match the preview for the same file
- [ ] Navigate between files quickly and confirm the last selected file stays on screen
- [ ] Open `/` and confirm the welcome page still appears
- [ ] `cd packages/frontend && npm test -- --testPathPatterns='contentSlice|outlineSlice|historySlice|MarkdownContent.test'`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented outdated content, outline, and diff responses from replacing newer results.
  * Cancelled in-progress requests when navigating away or starting a new request.
  * Improved handling of special characters and malformed paths.
  * Preserved correct history when loading pages directly or during server-side rendering.
  * Prevented cancelled requests from appearing as errors.

* **Tests**
  * Added coverage for request cancellation, stale responses, path handling, and history initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->