### PR TITLE
fix: serve markdown files inside dot-directories

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -106,6 +106,12 @@ export const createApp = (
       return res.status(403).send('Forbidden');
     }
 
+    // /api/markdown is only used to fetch markdown. Keep that contract so
+    // enabling dotfiles below cannot expose .env, .git/config, and similar.
+    if (!/\.(md|markdown)$/i.test(normalizedPath)) {
+      return res.status(404).send('File not found');
+    }
+
     if (!fs.existsSync(filePath)) {
       logger.error(`🚫 File not found: ${filePath}`);
       return res.status(404).send('File not found');

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -112,7 +112,9 @@ export const createApp = (
     }
     next();
   });
-  app.use('/api/markdown', express.static(directory));
+  // Default express.static ignores dot-segments, so /.hidden/file.md would
+  // fall through to the SPA catch-all and return index.html as "markdown".
+  app.use('/api/markdown', express.static(directory, { dotfiles: 'allow' }));
 
   // Catch-all route to serve index.html for any other requests
   app.get('*splat', async (req, res) => {

--- a/test/e2e/server.test.ts
+++ b/test/e2e/server.test.ts
@@ -51,6 +51,17 @@ describe('Server E2E Tests', () => {
     expect(res.text).not.toContain('<title>mdts - Markdown file viewer</title>');
   });
 
+  it('GET /api/markdown/.git/config should not be served', async () => {
+    const res = await request(app).get('/api/markdown/.git/config');
+    expect(res.statusCode).toEqual(404);
+  });
+
+  it('GET /api/markdown/.env should not be served even when the file exists', async () => {
+    const res = await request(app).get('/api/markdown/.env');
+    expect(res.statusCode).toEqual(404);
+    expect(res.text).toEqual('File not found');
+  });
+
   it('GET /api/outline should return the outline for a markdown file', async () => {
     const res = await request(app).get('/api/outline?filePath=test.md');
     expect(res.statusCode).toEqual(200);

--- a/test/e2e/server.test.ts
+++ b/test/e2e/server.test.ts
@@ -43,6 +43,14 @@ describe('Server E2E Tests', () => {
     expect(res.text).toContain('# Hello E2E');
   });
 
+  it('GET /api/markdown/.hidden/readme.md should return markdown from a dot-directory', async () => {
+    const res = await request(app).get('/api/markdown/.hidden/readme.md');
+    expect(res.statusCode).toEqual(200);
+    expect(res.headers['content-type']).toMatch(/markdown|plain|octet-stream/);
+    expect(res.text).toContain('# Hidden directory markdown');
+    expect(res.text).not.toContain('<title>mdts - Markdown file viewer</title>');
+  });
+
   it('GET /api/outline should return the outline for a markdown file', async () => {
     const res = await request(app).get('/api/outline?filePath=test.md');
     expect(res.statusCode).toEqual(200);

--- a/test/fixtures/mountDirectory/content/.env
+++ b/test/fixtures/mountDirectory/content/.env
@@ -1,0 +1,1 @@
+SECRET=should-not-be-served

--- a/test/fixtures/mountDirectory/content/.hidden/readme.md
+++ b/test/fixtures/mountDirectory/content/.hidden/readme.md
@@ -1,0 +1,3 @@
+# Hidden directory markdown
+
+This file lives under a dot-directory.

--- a/test/unit/server/server.test.ts
+++ b/test/unit/server/server.test.ts
@@ -79,11 +79,6 @@ describe('server.ts unit tests', () => {
       expect(app.use).toHaveBeenCalledWith(expect.any(Function)); // for express.static
     });
 
-    it('should allow serving markdown files from dot-directories', () => {
-      const express = jest.requireMock('express');
-      expect(express.static).toHaveBeenCalledWith('/mock/directory', { dotfiles: 'allow' });
-    });
-
     it('should define /api/filetree and /api/outline routes', () => {
       expect(app.use).toHaveBeenCalledWith('/api/filetree', expect.objectContaining({ get: expect.any(Function) }));
       expect(app.use).toHaveBeenCalledWith('/api/outline', expect.objectContaining({ get: expect.any(Function) }));
@@ -186,6 +181,26 @@ describe('server.ts unit tests', () => {
       expect(mockStatus).toHaveBeenCalledWith(404);
       expect(mockSend).toHaveBeenCalledWith('File not found');
       expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it('should return 404 for non-markdown files in /api/markdown', async () => {
+      (fs.existsSync as jest.Mock).mockReturnValue(true);
+      const mockStatus = jest.fn().mockReturnThis();
+      const mockSend = jest.fn();
+      const mockNext = jest.fn();
+      const req = { path: '.git/config' } as Request;
+      const res = { status: mockStatus, send: mockSend } as unknown as Response;
+
+      const markdownMiddleware = (app.use as jest.Mock).mock.calls.find(
+        (call: [string, (req: Request, res: Response, next: NextFunction) => void]) =>
+          call[0] === '/api/markdown' && call.length === 2,
+      )[1];
+      await markdownMiddleware(req, res, mockNext);
+
+      expect(mockStatus).toHaveBeenCalledWith(404);
+      expect(mockSend).toHaveBeenCalledWith('File not found');
+      expect(mockNext).not.toHaveBeenCalled();
+      expect(fs.existsSync).not.toHaveBeenCalled();
     });
 
     it('should call next for existing files in /api/markdown', async () => {

--- a/test/unit/server/server.test.ts
+++ b/test/unit/server/server.test.ts
@@ -79,6 +79,11 @@ describe('server.ts unit tests', () => {
       expect(app.use).toHaveBeenCalledWith(expect.any(Function)); // for express.static
     });
 
+    it('should allow serving markdown files from dot-directories', () => {
+      const express = jest.requireMock('express');
+      expect(express.static).toHaveBeenCalledWith('/mock/directory', { dotfiles: 'allow' });
+    });
+
     it('should define /api/filetree and /api/outline routes', () => {
       expect(app.use).toHaveBeenCalledWith('/api/filetree', expect.objectContaining({ get: expect.any(Function) }));
       expect(app.use).toHaveBeenCalledWith('/api/outline', expect.objectContaining({ get: expect.any(Function) }));


### PR DESCRIPTION
## Summary
- `/api/markdown` used `express.static` with the default `dotfiles: 'ignore'`, so a path like `/.layout-audit/fixes/README.md` skipped the file on disk and fell through to the SPA catch-all.
- The frontend then rendered `index.html` as markdown, which left the preview blank while the outline (read via `fs`) still looked correct.
- Allow dotfiles only on the markdown static mount and add unit/e2e coverage for a hidden-directory file.

## Test plan
- [ ] Open a markdown file under a dot-directory (e.g. `/.layout-audit/fixes/README.md`) and confirm PREVIEW shows the file body, not a blank page
- [ ] Confirm the outline/TOC for that file still matches the headings
- [ ] Open a normal file outside a dot-directory and confirm preview is unchanged
- [ ] `npm test -- --testPathPatterns=server.test --no-coverage`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Markdown files inside hidden directories are now served correctly through the markdown endpoint.
  * Hidden non-Markdown files, including configuration and repository files, are no longer accessible through the endpoint and return a 404 response.

* **Tests**
  * Added coverage for serving hidden-directory Markdown files and rejecting hidden non-Markdown files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->