### PR TITLE
chore(deps): bump @mui/material and @mui/icons-material to 9.4.0

### DIFF
--- a/packages/frontend/package-lock.json
+++ b/packages/frontend/package-lock.json
@@ -11,8 +11,8 @@
       "dependencies": {
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.5",
-        "@mui/icons-material": "^9.3.1",
-        "@mui/material": "^9.3.1",
+        "@mui/icons-material": "^9.4.0",
+        "@mui/material": "^9.4.0",
         "@mui/x-tree-view": "^9.12.0",
         "@reduxjs/toolkit": "^2.12.0",
         "buffer": "^6.0.3",
@@ -6306,9 +6306,9 @@
       }
     },
     "node_modules/@mui/core-downloads-tracker": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-9.3.1.tgz",
-      "integrity": "sha512-IAyAFNQbT7hysJ9HXphiOmWJF7G1OglzHanqCgvQgH9LA2ydxtmaTBDbcBqw6euZesyShiwvpvbnYO1GY1AyXQ==",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-9.4.0.tgz",
+      "integrity": "sha512-d+gIYM1raJP87yrVQcVg+Q3vycVMArMkgu/TjJLi2vTvO9FHKWNRR1xs9nnN4eLpM9nGxxm02UMvc9BrmcUKvQ==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -6316,9 +6316,9 @@
       }
     },
     "node_modules/@mui/icons-material": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-9.3.1.tgz",
-      "integrity": "sha512-rZj5ccG7vkpV38o/l4ys+chfE9GFypmvZr9dSNBoYVCNBD9yC6KfKq1TYpEMshWbjic7GKQ8MA1LQlcpGgcq9Q==",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-9.4.0.tgz",
+      "integrity": "sha512-5PVgBYtLOXTk6u0YUAjoV9GoTUQDbeZ8g+pus2h0GphLT/rpmftRnB5D/Kw6QCAovB7EyBX7UxKdZqPBBAHUKw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.29.7"
@@ -6331,7 +6331,7 @@
         "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
-        "@mui/material": "^9.3.1",
+        "@mui/material": "^9.4.0",
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
@@ -6342,16 +6342,16 @@
       }
     },
     "node_modules/@mui/material": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-9.3.1.tgz",
-      "integrity": "sha512-NahAEGIXqS1K0bA4th1jeFxBguS59NOcLbMA0vU+fSaPWKjtwGBGGHeTwlc9PSmzMjOZKceeFWESB8fVHr31hA==",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-9.4.0.tgz",
+      "integrity": "sha512-6KKUIvkQ2r/s48s9VZV9JEZ1W2dRa7RndVsF+Ipx4CYxDOQeozeRsS5r9NiheFf8A5hpbqJJIGoX7hjg5X4XUw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.29.7",
-        "@mui/core-downloads-tracker": "^9.3.1",
-        "@mui/system": "^9.3.0",
-        "@mui/types": "^9.3.0",
-        "@mui/utils": "^9.3.0",
+        "@mui/core-downloads-tracker": "^9.4.0",
+        "@mui/system": "^9.4.0",
+        "@mui/types": "^9.4.0",
+        "@mui/utils": "^9.4.0",
         "@popperjs/core": "^2.11.8",
         "@types/react-transition-group": "^4.4.12",
         "clsx": "^2.1.1",
@@ -6370,7 +6370,7 @@
       "peerDependencies": {
         "@emotion/react": "^11.5.0",
         "@emotion/styled": "^11.3.0",
-        "@mui/material-pigment-css": "^9.3.0",
+        "@mui/material-pigment-css": "^9.4.0",
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -6391,13 +6391,13 @@
       }
     },
     "node_modules/@mui/private-theming": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-9.3.0.tgz",
-      "integrity": "sha512-ERvqk5pejf9aRnQcDILSWGtFmsEMiVxlQ4+xsVCjsEvmK0fV9BiVP/cQwAF5dwyDFbve4lTrlcgeFEecVzTNiA==",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-9.4.0.tgz",
+      "integrity": "sha512-qQpX/2XPGDz5F2OIWzo4kkorURlDeXGKytRQudXCdLS5TuwKsMKaZyx77LZEVSB73c7o3UrLWwQ/goRuHBdtjw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.29.7",
-        "@mui/utils": "^9.3.0",
+        "@mui/utils": "^9.4.0",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -6418,9 +6418,9 @@
       }
     },
     "node_modules/@mui/styled-engine": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-9.3.0.tgz",
-      "integrity": "sha512-x9+KYxhjoHYZ4nioxdKnvQWdw0RScbhoZfQ4tv3Db742683U3wlYSp6zV6Us78dMFnKnyTrPTkQKyutp14gnKA==",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-9.4.0.tgz",
+      "integrity": "sha512-SlqVEYqnyEgXMFW4JuIDMelyhKzoWBJ85v2mNCQd0XtU0uk7U9E1zaJZ06XqodhA8oJrb+4Q+3E/JlwBe4jWkw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.29.7",
@@ -6452,16 +6452,16 @@
       }
     },
     "node_modules/@mui/system": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-9.3.0.tgz",
-      "integrity": "sha512-0l4LqHJxZj65xSrioniGsxm7VNoGXonPo203oZjhBUvIDPeBqRTb7Mqc45Qxs6sO6WGR7WE/9cJ6lb4lkvHkjg==",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-9.4.0.tgz",
+      "integrity": "sha512-AZz9z13oGS1J0BYeAFHTbV7PegCtPiE/uMEIi7TJ1kTx3Vkt+jUpLyXF/2uV8B6Y79iTh98kVeOH9fX3x3zXXg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.29.7",
-        "@mui/private-theming": "^9.3.0",
-        "@mui/styled-engine": "^9.3.0",
-        "@mui/types": "^9.3.0",
-        "@mui/utils": "^9.3.0",
+        "@mui/private-theming": "^9.4.0",
+        "@mui/styled-engine": "^9.4.0",
+        "@mui/types": "^9.4.0",
+        "@mui/utils": "^9.4.0",
         "clsx": "^2.1.1",
         "csstype": "^3.2.3",
         "prop-types": "^15.8.1"
@@ -6492,9 +6492,9 @@
       }
     },
     "node_modules/@mui/types": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-9.3.0.tgz",
-      "integrity": "sha512-2JSxyfpEFWNUB2vKs/T1BvkfyNisMHWph8bLMj8T0uHwmLl/0qfAwQkfwMT6kxLXN9uIum9AEbECXU8er3amIg==",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-9.4.0.tgz",
+      "integrity": "sha512-13DH0Oniua4WmGqeYbQAZqmiN7r4nfd0zwIoGJ5QeJwyIHgEmf+LkRw/jV1HZb6AiUoHX8Oxf4xgalq3vYHcIw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.29.7"
@@ -6509,13 +6509,13 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-9.3.0.tgz",
-      "integrity": "sha512-2HZdHwWJ6eB+7lVGSOHsByGw8jeRulT4g0NZ608Wb8Q57DE2jbNqrWPFuJsvkQQiBiTmlpvQL3i+/62zsiPrkw==",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-9.4.0.tgz",
+      "integrity": "sha512-WkzY8uYtqUDyGKPShrRQRBomfMQHddlsyKu/gRRESYO24tDPD2z0xRE8CBoUsWqpBa+YrFs9KixiS7kQRjsPAQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.29.7",
-        "@mui/types": "^9.3.0",
+        "@mui/types": "^9.4.0",
         "@types/prop-types": "^15.7.15",
         "clsx": "^2.1.1",
         "prop-types": "^15.8.1",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -18,8 +18,8 @@
   "dependencies": {
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",
-    "@mui/icons-material": "^9.3.1",
-    "@mui/material": "^9.3.1",
+    "@mui/icons-material": "^9.4.0",
+    "@mui/material": "^9.4.0",
     "@mui/x-tree-view": "^9.12.0",
     "@reduxjs/toolkit": "^2.12.0",
     "buffer": "^6.0.3",

--- a/packages/frontend/test/unit/components/Content/MarkdownContent/__snapshots__/MarkdownContent.test.tsx.snap
+++ b/packages/frontend/test/unit/components/Content/MarkdownContent/__snapshots__/MarkdownContent.test.tsx.snap
@@ -53,7 +53,7 @@ exports[`MarkdownContent renders welcome message when no file is selected 1`] = 
           >
             <button
               aria-selected="true"
-              class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary Mui-selected css-mobu7h-MuiButtonBase-root-MuiTab-root"
+              class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary Mui-selected css-r8v7co-MuiButtonBase-root-MuiTab-root"
               role="tab"
               tabindex="0"
               type="button"
@@ -62,7 +62,7 @@ exports[`MarkdownContent renders welcome message when no file is selected 1`] = 
             </button>
             <button
               aria-selected="false"
-              class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-mobu7h-MuiButtonBase-root-MuiTab-root"
+              class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-r8v7co-MuiButtonBase-root-MuiTab-root"
               role="tab"
               tabindex="-1"
               type="button"
@@ -71,7 +71,7 @@ exports[`MarkdownContent renders welcome message when no file is selected 1`] = 
             </button>
             <button
               aria-selected="false"
-              class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-mobu7h-MuiButtonBase-root-MuiTab-root"
+              class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-r8v7co-MuiButtonBase-root-MuiTab-root"
               role="tab"
               tabindex="-1"
               type="button"

--- a/packages/frontend/test/unit/components/Content/MarkdownContent/__snapshots__/MarkdownContentTabs.test.tsx.snap
+++ b/packages/frontend/test/unit/components/Content/MarkdownContent/__snapshots__/MarkdownContentTabs.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`MarkdownContentTabs renders preview and raw tabs by default 1`] = `
         >
           <button
             aria-selected="true"
-            class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary Mui-selected css-mobu7h-MuiButtonBase-root-MuiTab-root"
+            class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary Mui-selected css-r8v7co-MuiButtonBase-root-MuiTab-root"
             role="tab"
             tabindex="0"
             type="button"
@@ -28,7 +28,7 @@ exports[`MarkdownContentTabs renders preview and raw tabs by default 1`] = `
           </button>
           <button
             aria-selected="false"
-            class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-mobu7h-MuiButtonBase-root-MuiTab-root"
+            class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-r8v7co-MuiButtonBase-root-MuiTab-root"
             role="tab"
             tabindex="-1"
             type="button"
@@ -37,7 +37,7 @@ exports[`MarkdownContentTabs renders preview and raw tabs by default 1`] = `
           </button>
           <button
             aria-selected="false"
-            class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-mobu7h-MuiButtonBase-root-MuiTab-root"
+            class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-r8v7co-MuiButtonBase-root-MuiTab-root"
             role="tab"
             tabindex="-1"
             type="button"

--- a/packages/frontend/test/unit/components/LeftPane/__snapshots__/FileTree.test.tsx.snap
+++ b/packages/frontend/test/unit/components/LeftPane/__snapshots__/FileTree.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`FileTree renders correctly 1`] = `
         </h6>
         <button
           aria-label="expand all"
-          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-155wbr6-MuiButtonBase-root-MuiIconButton-root"
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1pdlxrj-MuiButtonBase-root-MuiIconButton-root"
           tabindex="0"
           type="button"
         >
@@ -36,7 +36,7 @@ exports[`FileTree renders correctly 1`] = `
         </button>
         <button
           aria-label="collapse all"
-          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-155wbr6-MuiButtonBase-root-MuiIconButton-root"
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1pdlxrj-MuiButtonBase-root-MuiIconButton-root"
           tabindex="0"
           type="button"
         >
@@ -55,7 +55,7 @@ exports[`FileTree renders correctly 1`] = `
       </div>
       <button
         aria-label="toggle file tree"
-        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1nyqon6-MuiButtonBase-root-MuiIconButton-root"
+        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1afdov1-MuiButtonBase-root-MuiIconButton-root"
         tabindex="0"
         type="button"
       >

--- a/packages/frontend/test/unit/components/LeftPane/__snapshots__/FileTreeHeader.test.tsx.snap
+++ b/packages/frontend/test/unit/components/LeftPane/__snapshots__/FileTreeHeader.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`FileTreeHeader renders correctly when closed 1`] = `
   >
     <button
       aria-label="toggle file tree"
-      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-130mf42-MuiButtonBase-root-MuiIconButton-root"
+      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1myvn3n-MuiButtonBase-root-MuiIconButton-root"
       tabindex="0"
       type="button"
     >
@@ -42,7 +42,7 @@ exports[`FileTreeHeader renders correctly when open 1`] = `
       </h6>
       <button
         aria-label="expand all"
-        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-155wbr6-MuiButtonBase-root-MuiIconButton-root"
+        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1pdlxrj-MuiButtonBase-root-MuiIconButton-root"
         tabindex="0"
         type="button"
       >
@@ -60,7 +60,7 @@ exports[`FileTreeHeader renders correctly when open 1`] = `
       </button>
       <button
         aria-label="collapse all"
-        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-155wbr6-MuiButtonBase-root-MuiIconButton-root"
+        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1pdlxrj-MuiButtonBase-root-MuiIconButton-root"
         tabindex="0"
         type="button"
       >
@@ -79,7 +79,7 @@ exports[`FileTreeHeader renders correctly when open 1`] = `
     </div>
     <button
       aria-label="toggle file tree"
-      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1nyqon6-MuiButtonBase-root-MuiIconButton-root"
+      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1afdov1-MuiButtonBase-root-MuiIconButton-root"
       tabindex="0"
       type="button"
     >

--- a/packages/frontend/test/unit/components/LeftPane/__snapshots__/FileTreeSearch.test.tsx.snap
+++ b/packages/frontend/test/unit/components/LeftPane/__snapshots__/FileTreeSearch.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`FileTreeSearch renders correctly with a search query 1`] = `
       >
         <button
           aria-label="clear search"
-          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeSmall css-1eswsun-MuiButtonBase-root-MuiIconButton-root"
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeSmall css-1owpdbk-MuiButtonBase-root-MuiIconButton-root"
           tabindex="0"
           type="button"
         >

--- a/packages/frontend/test/unit/components/RightPane/__snapshots__/Outline.test.tsx.snap
+++ b/packages/frontend/test/unit/components/RightPane/__snapshots__/Outline.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`Outline renders correctly 1`] = `
     >
       <button
         aria-label="toggle outline"
-        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1nyqon6-MuiButtonBase-root-MuiIconButton-root"
+        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1afdov1-MuiButtonBase-root-MuiIconButton-root"
         tabindex="0"
         type="button"
       >

--- a/packages/frontend/test/unit/components/RightPane/__snapshots__/OutlineHeader.test.tsx.snap
+++ b/packages/frontend/test/unit/components/RightPane/__snapshots__/OutlineHeader.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`OutlineHeader renders correctly when closed 1`] = `
   >
     <button
       aria-label="toggle outline"
-      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-130mf42-MuiButtonBase-root-MuiIconButton-root"
+      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1myvn3n-MuiButtonBase-root-MuiIconButton-root"
       tabindex="0"
       type="button"
     >
@@ -34,7 +34,7 @@ exports[`OutlineHeader renders correctly when open 1`] = `
   >
     <button
       aria-label="toggle outline"
-      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1nyqon6-MuiButtonBase-root-MuiIconButton-root"
+      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1afdov1-MuiButtonBase-root-MuiIconButton-root"
       tabindex="0"
       type="button"
     >

--- a/packages/frontend/test/unit/components/SettingsDialog/__snapshots__/ColorSchemeSettingsTab.test.tsx.snap
+++ b/packages/frontend/test/unit/components/SettingsDialog/__snapshots__/ColorSchemeSettingsTab.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`ColorSchemeSettingsTab should render correctly 1`] = `
       <button
         aria-label="dark"
         aria-pressed="true"
-        class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButton-root Mui-selected MuiToggleButton-fullWidth MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-firstButton css-zhjb61-MuiButtonBase-root-MuiToggleButton-root"
+        class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButton-root Mui-selected MuiToggleButton-fullWidth MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-firstButton css-dc1ptf-MuiButtonBase-root-MuiToggleButton-root"
         tabindex="0"
         type="button"
         value="dark"
@@ -28,7 +28,7 @@ exports[`ColorSchemeSettingsTab should render correctly 1`] = `
       <button
         aria-label="light"
         aria-pressed="false"
-        class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButton-root MuiToggleButton-fullWidth MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-middleButton css-zhjb61-MuiButtonBase-root-MuiToggleButton-root"
+        class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButton-root MuiToggleButton-fullWidth MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-middleButton css-dc1ptf-MuiButtonBase-root-MuiToggleButton-root"
         tabindex="-1"
         type="button"
         value="light"
@@ -38,7 +38,7 @@ exports[`ColorSchemeSettingsTab should render correctly 1`] = `
       <button
         aria-label="auto"
         aria-pressed="false"
-        class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButton-root MuiToggleButton-fullWidth MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-lastButton css-zhjb61-MuiButtonBase-root-MuiToggleButton-root"
+        class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButton-root MuiToggleButton-fullWidth MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-lastButton css-dc1ptf-MuiButtonBase-root-MuiToggleButton-root"
         tabindex="-1"
         type="button"
         value="auto"

--- a/packages/frontend/test/unit/components/SettingsDialog/__snapshots__/FontSettingsTab.test.tsx.snap
+++ b/packages/frontend/test/unit/components/SettingsDialog/__snapshots__/FontSettingsTab.test.tsx.snap
@@ -96,7 +96,7 @@ exports[`FontSettingsTab should render correctly 1`] = `
         style="left: 100%;"
       />
       <span
-        class="MuiSlider-thumb MuiSlider-thumb css-1n6bc4q-MuiSlider-thumb"
+        class="MuiSlider-thumb MuiSlider-thumb css-398ij6-MuiSlider-thumb"
         data-index="0"
         style="left: 0%;"
       >
@@ -111,7 +111,7 @@ exports[`FontSettingsTab should render correctly 1`] = `
           max="24"
           min="10"
           step="1"
-          style="border: 0px; height: 100%; margin: -1px; overflow: hidden; padding: 0px; position: absolute; white-space: nowrap; width: 100%; direction: ltr;"
+          style="border: 0px; clip-path: inset(50%); height: 100%; margin: -1px; overflow: hidden; padding: 0px; position: absolute; white-space: nowrap; width: 100%; direction: ltr;"
           type="range"
           value="10"
         />
@@ -146,7 +146,7 @@ exports[`FontSettingsTab should render correctly 1`] = `
         class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
       >
         <span
-          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall css-1q72ply-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
+          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall css-1tpgjhd-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
         >
           <input
             class="PrivateSwitchBase-input css-gjsmck-MuiSwitchBase-root"
@@ -191,7 +191,7 @@ exports[`FontSettingsTab should render correctly 1`] = `
         class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
       >
         <span
-          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall css-1q72ply-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
+          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall css-1tpgjhd-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
         >
           <input
             class="PrivateSwitchBase-input css-gjsmck-MuiSwitchBase-root"
@@ -279,7 +279,7 @@ exports[`FontSettingsTab should render correctly 1`] = `
         class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
       >
         <span
-          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall css-1q72ply-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
+          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall css-1tpgjhd-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
         >
           <input
             class="PrivateSwitchBase-input css-gjsmck-MuiSwitchBase-root"
@@ -324,7 +324,7 @@ exports[`FontSettingsTab should render correctly 1`] = `
         class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
       >
         <span
-          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall css-1q72ply-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
+          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall css-1tpgjhd-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
         >
           <input
             class="PrivateSwitchBase-input css-gjsmck-MuiSwitchBase-root"

--- a/packages/frontend/test/unit/components/SettingsDialog/__snapshots__/LayoutSettingsTab.test.tsx.snap
+++ b/packages/frontend/test/unit/components/SettingsDialog/__snapshots__/LayoutSettingsTab.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`LayoutSettingsTab should render correctly 1`] = `
       <button
         aria-label="full"
         aria-pressed="false"
-        class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButton-root MuiToggleButton-fullWidth MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-firstButton css-zhjb61-MuiButtonBase-root-MuiToggleButton-root"
+        class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButton-root MuiToggleButton-fullWidth MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-firstButton css-dc1ptf-MuiButtonBase-root-MuiToggleButton-root"
         tabindex="0"
         type="button"
         value="full"
@@ -28,7 +28,7 @@ exports[`LayoutSettingsTab should render correctly 1`] = `
       <button
         aria-label="compact"
         aria-pressed="true"
-        class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButton-root Mui-selected MuiToggleButton-fullWidth MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-lastButton css-zhjb61-MuiButtonBase-root-MuiToggleButton-root"
+        class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButton-root Mui-selected MuiToggleButton-fullWidth MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-lastButton css-dc1ptf-MuiButtonBase-root-MuiToggleButton-root"
         tabindex="-1"
         type="button"
         value="compact"
@@ -48,7 +48,7 @@ exports[`LayoutSettingsTab should render correctly 1`] = `
         class="MuiSwitch-root MuiSwitch-sizeSmall css-fzgmul-MuiSwitch-root"
       >
         <span
-          class="MuiButtonBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary PrivateSwitchBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary css-1c6expc-MuiButtonBase-root-MuiSwitchBase-root-MuiSwitch-switchBase"
+          class="MuiButtonBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary PrivateSwitchBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary css-1vhsptr-MuiButtonBase-root-MuiSwitchBase-root-MuiSwitch-switchBase"
         >
           <input
             class="PrivateSwitchBase-input MuiSwitch-input css-gjsmck-MuiSwitchBase-root"

--- a/packages/frontend/test/unit/components/__snapshots__/AppHeader.test.tsx.snap
+++ b/packages/frontend/test/unit/components/__snapshots__/AppHeader.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`AppHeader renders correctly 1`] = `
       >
         <button
           aria-label="Top page"
-          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeMedium css-1vqxir3-MuiButtonBase-root-MuiIconButton-root"
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeMedium css-1w0p6kw-MuiButtonBase-root-MuiIconButton-root"
           data-mui-internal-clone-element="true"
           tabindex="0"
           type="button"
@@ -108,7 +108,7 @@ exports[`AppHeader renders correctly 1`] = `
       </div>
       <button
         aria-label="Settings"
-        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeMedium css-v8k5r1-MuiButtonBase-root-MuiIconButton-root"
+        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeMedium css-1din4kw-MuiButtonBase-root-MuiIconButton-root"
         data-mui-internal-clone-element="true"
         tabindex="0"
         type="button"
@@ -127,7 +127,7 @@ exports[`AppHeader renders correctly 1`] = `
       </button>
       <a
         aria-label="GitHub Repository"
-        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeMedium css-v8k5r1-MuiButtonBase-root-MuiIconButton-root"
+        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeMedium css-1din4kw-MuiButtonBase-root-MuiIconButton-root"
         data-mui-internal-clone-element="true"
         href="https://github.com/unhappychoice/mdts"
         rel="noopener"


### PR DESCRIPTION
Supersedes #910 and #914.

## Why one PR instead of two

`packages/frontend/package.json` declares both packages with a caret range (`^9.3.1`), so each Dependabot PR resolves `@mui/material` to 9.4.0 in its lockfile. Both therefore hit the same snapshot failures and cannot be merged independently — the second would conflict on the same `.snap` files. Bumping them together keeps the MUI packages in lockstep.

## Why `test-frontend` was failing

13 snapshots across 11 suites. The diff is:

- emotion class-name hash churn (`css-130mf42` → `css-1myvn3n`, etc.)
- one real upstream change: MUI's `visuallyHidden` style now emits `clip-path: inset(50%)` instead of the deprecated `clip` property.

No behavioral regression — snapshots regenerated with `npm run jest -- --selectProjects test -u`.

## Verification

- `npm run test:frontend` → 56 suites / 321 tests passed
- `npm run lint:frontend` → 124 suites passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the underlying interface libraries to newer versions.
  - No direct user-facing changes are included in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->